### PR TITLE
GitHub Action to publish build to gh-pages branch

### DIFF
--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -1,15 +1,18 @@
 name: Build and Deploy
-on: [push]
+on:
+  push:
+    branches:
+      - master
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2.3.1 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        uses: actions/checkout@v2.3.1
         with:
           persist-credentials: false
 
-      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+      - name: Install and Build 🔧
         run: |
           npm install
           npm run build


### PR DESCRIPTION
**NOTE: #2 is a pre-requisite PR for this PR to work**

This Github action will:
- checkout the repository
- run `npm install`
- run `build`
- copy files from `/dist` build folder and force push changes to `gh-pages` branch

Once `gh-pages` branch is set to publish, it will push those assets to a github.io page. 

This will later be pushed to https://cadenceworkflow.io/ in a future PR once this is tested and working.

## Screenshots
**GitHub Action**
<img width="958" alt="Screen Shot 2020-10-30 at 10 48 42 AM" src="https://user-images.githubusercontent.com/58960161/97739851-a677f880-1a9d-11eb-8761-da0599b86877.png">

**generated gh-pages branch**
<img width="1121" alt="Screen Shot 2020-10-30 at 10 48 31 AM" src="https://user-images.githubusercontent.com/58960161/97739881-aed03380-1a9d-11eb-8ea9-0c03ce044f34.png">