### PR TITLE
Fixed code snipet in Child workflows documentation

### DIFF
--- a/src/docs/05-go-client/05-child-workflows.md
+++ b/src/docs/05-go-client/05-child-workflows.md
@@ -16,7 +16,7 @@ cwo := workflow.ChildWorkflowOptions{
     WorkflowID:                   "BID-SIMPLE-CHILD-WORKFLOW",
     ExecutionStartToCloseTimeout: time.Minute * 30,
 }
-ctx = workflow.WithChildWorkflowOptions(ctx, cwo)
+ctx = workflow.WithChildOptions(ctx, cwo)
 
 var result string
 future := workflow.ExecuteChildWorkflow(ctx, SimpleChildWorkflow, value)


### PR DESCRIPTION
In the Golang client documentation, in the section that details Child Workflows, fixed the code snipet, by replacing `worflow.WithChildWorkflowOption()` with `workflow.WithChildOptions()`.
