### PR TITLE
Enable deployments

### DIFF
--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -73,9 +73,9 @@ jobs:
           npm install
           npm run build
 
-      # - name: Deploy 🚀
-      #   uses: JamesIves/github-pages-deploy-action@v4
-      #   with:
-      #     branch: gh-pages # The branch the action should deploy to.
-      #     folder: build # The folder the action should deploy.
-      #     clean: true # Automatically remove deleted files from the deploy branch
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: build # The folder the action should deploy.
+          clean: true # Automatically remove deleted files from the deploy branch


### PR DESCRIPTION
Checked environment variables at the build step on the deployment GH action.

Run: https://github.com/cadence-workflow/Cadence-Docs/actions/runs/12602826174/job/35126630404

It's correct, CADENCE_DOCS_URL is redacted automatically since it's stored as a secret.
```
CADENCE_DOCS_URL is https://***
PROJECT_NAME is Cadence-Docs
BASE_URL is /
ORGANIZATION_NAME is cadence-workflow
```

In case something goes wrong, it can be deployed from a local environment:

```
## Production Configuration (.envrc.local)
export CADENCE_DOCS_URL=https://cadenceworkflow.io
export BASE_URL=/
export ORGANIZATION_NAME=cadence-workflow
export PROJECT_NAME=Cadence-Docs

touch static/CNAME
echo "cadenceworkflow.io" > static/CNAME
npm run deploy
```