### PR TITLE
Fix author attribution based on git history

### DIFF
--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       # configure custom domain for github pages


### PR DESCRIPTION
This copies repo history in order to show author attribution based on commit history.

https://github.com/actions/checkout?tab=readme-ov-file#fetch-all-history-for-all-tags-and-branches

