### PR TITLE
Updated the cluster command to the new syntax with a ,

### DIFF
--- a/docs/03-concepts/08-cross-dc-replication.md
+++ b/docs/03-concepts/08-cross-dc-replication.md
@@ -173,7 +173,7 @@ clusterMetadata:
 After the configuration is deployed:
 
 1. Register a global domain
-`cadence --do <domain_name> domain register --global_domain true  --clusters clusterDCA clusterDCB --active_cluster clusterDCA`
+`cadence --do <domain_name> domain register --global_domain true  --clusters clusterDCA,clusterDCB --active_cluster clusterDCA`
 
 
 2. Run some workflow and failover domain from one to another

--- a/docs/06-cli/index.md
+++ b/docs/06-cli/index.md
@@ -190,7 +190,7 @@ cadence --do samples-domain d re
 ```
 If your Cadence cluster has enable [global domain(XDC replication)](https://cadenceworkflow.io/docs/concepts/cross-dc-replication/), then you have to specify the replicaiton settings when registering a domain:
 ```bash
-cadence --domains amples-domain domain register --active_cluster clusterNameA --clusters clusterNameA clusterNameB
+cadence --domains amples-domain domain register --active_cluster clusterNameA --clusters clusterNameA,clusterNameB
 ```
 
 - View "samples-domain" details:

--- a/docs/07-operation-guide/05-migration.md
+++ b/docs/07-operation-guide/05-migration.md
@@ -124,7 +124,7 @@ First of all, try replicating a single domain to make sure everything work. Here
 
 * 2.1 Assuming the domain only contain `currentCluster` in the cluster list, let's add the new cluster to the domain.
 ```bash
-cadence --address <currentClusterAddress> --do <domain_name> domain update --clusters <currentClusterName> <newClusterName>
+cadence --address <currentClusterAddress> --do <domain_name> domain update --clusters <currentClusterName>,<newClusterName>
 ```
 
 Run the command below to refresh the domain after adding a new cluster to the cluster list; we need to update the active_cluster to the same value that it appears to be.


### PR DESCRIPTION
Updating the cluster configu documentation to match the new syntax, see PR: https://github.com/cadence-workflow/cadence/pull/6658 for context
