### PR TITLE
Fix gRPC API link

### DIFF
--- a/docs/03-concepts/05-topology.md
+++ b/docs/03-concepts/05-topology.md
@@ -18,7 +18,7 @@ Note that both types of :worker:workers: as well as external clients are roles a
 ![Cadence Architecture](https://user-images.githubusercontent.com/14902200/160308507-2854a98a-0582-4748-87e4-e0695d3b6e86.jpg)
 
 
-At the core of Cadence is a highly scalable multitenant service. The service exposes all of its functionality through a strongly typed [gRPC API](https://github.com/cadence-workflow/cadence-idl/tree/master/proto/cadence-workflow/cadence/api/v1). A Cadence cluster include multiple services, each of which may run on multiple nodes for scalability and reliablity:
+At the core of Cadence is a highly scalable multitenant service. The service exposes all of its functionality through a strongly typed [gRPC API](https://github.com/cadence-workflow/cadence-idl/tree/master/go/proto/api/v1). A Cadence cluster include multiple services, each of which may run on multiple nodes for scalability and reliablity:
 - Front End: which is a stateless service used to handle incoming requests from Workers. It is expected that an external load balancing mechanism is used to distribute load between Front End instances.
 - History Service: where the core logic of orchestrating workflow steps and activities is implemented
 - Matching Service: matches workflow/activity tasks that need to be executed to workflow/activity workers that are able to execute them. Matching is assigned task for execution by the history service

--- a/docs/03-concepts/05-topology.md
+++ b/docs/03-concepts/05-topology.md
@@ -18,7 +18,7 @@ Note that both types of :worker:workers: as well as external clients are roles a
 ![Cadence Architecture](https://user-images.githubusercontent.com/14902200/160308507-2854a98a-0582-4748-87e4-e0695d3b6e86.jpg)
 
 
-At the core of Cadence is a highly scalable multitenant service. The service exposes all of its functionality through a strongly typed [gRPC API](https://github.com/cadence-workflow/cadence-idl/tree/master/go/proto/api/v1). A Cadence cluster include multiple services, each of which may run on multiple nodes for scalability and reliablity:
+At the core of Cadence is a highly scalable multitenant service. The service exposes all of its functionality through a strongly typed [gRPC API](https://github.com/cadence-workflow/cadence-idl/tree/master/proto/uber/cadence/api/v1). A Cadence cluster include multiple services, each of which may run on multiple nodes for scalability and reliablity:
 - Front End: which is a stateless service used to handle incoming requests from Workers. It is expected that an external load balancing mechanism is used to distribute load between Front End instances.
 - History Service: where the core logic of orchestrating workflow steps and activities is implemented
 - Matching Service: matches workflow/activity tasks that need to be executed to workflow/activity workers that are able to execute them. Matching is assigned task for execution by the history service


### PR DESCRIPTION
The link to gRPC API was broken, leading to 404 error.