### PR TITLE
Fix for Incorrect curl command to download compose files

### DIFF
--- a/docs/01-get-started/01-server-installation.md
+++ b/docs/01-get-started/01-server-installation.md
@@ -22,7 +22,7 @@ Download the Cadence docker-compose file:
 
 Clone the repo
 ```bash
-git clone https://github.com/cadence-workflow/Cadence-Docs.git
+git clone https://github.com/cadence-workflow/cadence.git
 ```
 Then start Cadence Service by running:
 Run docker-compose in docker folder

--- a/docs/01-get-started/01-server-installation.md
+++ b/docs/01-get-started/01-server-installation.md
@@ -26,7 +26,7 @@ git clone https://github.com/cadence-workflow/cadence.git
 ```
 Then start Cadence Service by running:
 ```bash
-cd docker && docker-compose up
+cd cadence/docker && docker-compose up
 ```
 Please keep this process running at background.
 

--- a/docs/01-get-started/01-server-installation.md
+++ b/docs/01-get-started/01-server-installation.md
@@ -25,7 +25,6 @@ Clone the repo
 git clone https://github.com/cadence-workflow/cadence.git
 ```
 Then start Cadence Service by running:
-Run docker-compose in docker folder
 ```bash
 cd docker && docker-compose up
 ```

--- a/docs/01-get-started/01-server-installation.md
+++ b/docs/01-get-started/01-server-installation.md
@@ -22,7 +22,7 @@ Download the Cadence docker-compose file:
 
 Clone the repo
 ```bash
-git clone ..
+git clone https://github.com/cadence-workflow/Cadence-Docs.git
 ```
 Then start Cadence Service by running:
 Run docker-compose in docker folder

--- a/docs/01-get-started/01-server-installation.md
+++ b/docs/01-get-started/01-server-installation.md
@@ -20,12 +20,14 @@ Follow the Docker installation instructions found here: [https://docs.docker.com
 
 Download the Cadence docker-compose file:
 
+Clone the repo
 ```bash
-curl -O https://raw.githubusercontent.com/cadence-workflow/cadence/master/docker/docker-compose.yml && curl -O https://raw.githubusercontent.com/cadence-workflow/cadence/master/docker/prometheus/prometheus.yml
+git clone ..
 ```
 Then start Cadence Service by running:
+Run docker-compose in docker folder
 ```bash
-git clone .. && cd docker && docker-compose up
+cd docker && docker-compose up
 ```
 Please keep this process running at background.
 

--- a/docs/01-get-started/01-server-installation.md
+++ b/docs/01-get-started/01-server-installation.md
@@ -25,7 +25,7 @@ curl -O https://raw.githubusercontent.com/cadence-workflow/cadence/master/docker
 ```
 Then start Cadence Service by running:
 ```bash
-docker-compose up
+git clone .. && cd docker && docker-compose up
 ```
 Please keep this process running at background.
 


### PR DESCRIPTION
**What changed?**
Fix for Incorrect curl command to download compose files

**Why?**
https://github.com/cadence-workflow/Cadence-Docs/issues/230

Hi, So in reference to this https://github.com/cadence-workflow/Cadence-Docs/issues/171. I think it still persists. So running the curl command mentioned in the docs

curl -O https://raw.githubusercontent.com/cadence-workflow/cadence/master/docker/docker-compose.yml && curl -O https://raw.githubusercontent.com/cadence-workflow/cadence/master/docker/prometheus/prometheus.yml
This only downloads docker-compose.yml and promethues.yml

.
├── docker-compose.yml
└── prometheus.yml
But inside docker-compose.yml it clearly has these volumes under promethues and grafana service. Prometheus looks for prometheus.yml inside promethues directory and Grafana looks for grafana.ini inside grafana directory. Both of these are not downloaded with above curl command.

...
prometheus:
    image: prom/prometheus:latest
    volumes:
      - ./prometheus:/etc/prometheus
    command:
      - '--config.file=/etc/prometheus/prometheus.yml'
    ports:
      - '9090:9090'
....
grafana:
    image: grafana/grafana
    volumes:
      - ./grafana:/etc/grafana
    user: "1000"
    depends_on:
      - prometheus
    ports:
      - '3000:3000'

**How did you test it?**
locally

**Potential risks**
LOW