### PR TITLE
[Wf-Diagnostics] add a section on HB timeout set equal to StartToClose Timeout

### DIFF
--- a/docs/08-workflow-troubleshooting/01-timeouts.md
+++ b/docs/08-workflow-troubleshooting/01-timeouts.md
@@ -35,6 +35,8 @@ Activities time out StartToClose or ScheduleToClose if the activity took longer 
 
 For long running activities, while the activity is executing, the worker can die due to regular deployments or host restarts or failures. Cadence doesn't know about this and will wait for StartToClose or ScheduleToClose timeouts to kick in.
 
+[Read more abut long running activites](https://cadenceworkflow.io/docs/concepts/activities/#long-running-activities)
+
 Mitigation: Consider configuring heartbeat timeout and a retry policy
 
 [Example](https://github.com/cadence-workflow/cadence-samples/blob/df6f7bdba978d6565ad78e9f86d9cd31dfac9f78/cmd/samples/expense/workflow.go#L23)

--- a/docs/08-workflow-troubleshooting/03-retries.md
+++ b/docs/08-workflow-troubleshooting/03-retries.md
@@ -30,4 +30,8 @@ In both activity retries and workflow retries it is sufficient to mention a maxi
 
 In both activity retries and workflow retries it is sufficient to specify a maximum number of attempts or an expiration interval. The first retry attempt waits for the InitialIntervalInSeconds before starting and when an expiration interval is set lower than the initial interval, the retry policy becomes invalid and the activity or workflow will not be retried.
 
+## Heartbeat timeout being equal or higher than StartToClose timeout
 
+Heartbeat timeouts are used to detect when a worker died or restarted. With heartbeat timeout configured equal or higher than StartToClose timeout, cadence will timeout on the StartToClose timeout which essentially makes the configured heartbeat timeout to become useless. Ideally heartbeat timeouts should be configured to a few minutes so you can catch issues with the worker faster.
+
+[Read more abut long running activites](https://cadenceworkflow.io/docs/concepts/activities/#long-running-activities)


### PR DESCRIPTION
HB timeouts sometimes are set the same as other timeouts without the realisation of the functionality it provides