### PR TITLE
Add attribution for caniuse-lite and mdn-data in NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -17,3 +17,9 @@ Permission is hereby granted, free of charge, to any person obtaining a copy
  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
+
+This project depends on caniuse-lite by Browserslist, licensed under CC-BY-4.0.
+License: https://creativecommons.org/licenses/by/4.0/
+
+This project depends on mdn-data by MDN Web Docs, licensed under CC0-1.0.
+License: https://creativecommons.org/publicdomain/zero/1.0/


### PR DESCRIPTION
**What changed?**
Added proper attribution for these packages along with links to their respective Creative Commons licenses.
