### PR TITLE
Fix spacing in Search Workflows title

### DIFF
--- a/docs/03-concepts/09-search-workflows.md
+++ b/docs/03-concepts/09-search-workflows.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Search workflows(Advanced visibility)
+title: Search workflows (Advanced visibility)
 permalink: /docs/concepts/search-workflows
 ---
 
-# Searching Workflows(Advanced visibility)
+# Searching Workflows (Advanced visibility)
 
 ## Introduction
 


### PR DESCRIPTION
## Summary 
Add a space between the title and opening brackets for the Search Workflows page.

## Test plan
Ran locally.

### Before
<img width="1512" height="822" alt="Screenshot 2025-10-03 at 10 55 48" src="https://github.com/user-attachments/assets/07b83d98-058a-4467-944e-213e0f81b897" />

### After
<img width="1512" height="822" alt="Screenshot 2025-10-03 at 10 55 37" src="https://github.com/user-attachments/assets/07203512-7c78-4583-a0a5-e8a667d9d840" />

