### PR TITLE
docs(community): update Seva Kaloshin profile on team page

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -120,7 +120,7 @@ adhityamamallan:
 
 arzonus:
   name: Seva Kaloshin
-  title: Software Engineer II @ Uber
+  title: Senior Software Engineer @ Uber
   url: https://www.linkedin.com/in/seva-kaloshin/
   image_url: https://github.com/arzonus.png
   page: true

--- a/src/components/TeamProfileCards/index.tsx
+++ b/src/components/TeamProfileCards/index.tsx
@@ -135,7 +135,9 @@ export function MaintainersRow(): JSX.Element {
       <TeamProfileCardCol name="Tim Li" githubUrl="https://github.com/timl3136"> </TeamProfileCardCol>
       <TeamProfileCardCol name="tubignat" githubUrl="https://github.com/tubignat"> </TeamProfileCardCol>
       <TeamProfileCardCol name="Vinay Kumar Yadav" githubUrl="https://github.com/vinay116"> </TeamProfileCardCol>
-      <TeamProfileCardCol name="Vsevolod Kaloshin" githubUrl="https://github.com/arzonus"> </TeamProfileCardCol>
+      <TeamProfileCardCol name="Seva Kaloshin" githubUrl="https://github.com/arzonus" linkedinUrl="https://www.linkedin.com/in/seva-kaloshin/">
+        Seva was born and grew up in Saint Petersburg, Russia, and studied Information Security at Saint Petersburg Electrotechnical University. Throughout his career he's worked across both DevOps and backend engineering — rarely one without the other. When he's not working on Cadence, he's spending time with his wife and two kids in Denmark.
+      </TeamProfileCardCol>
     </div>
   );
 }


### PR DESCRIPTION
**What changed?**
Updated Seva Kaloshin's profile on the team page:
- Changed name from "Vsevolod Kaloshin" to "Seva Kaloshin" in TeamProfileCards
- Added bio and LinkedIn link to the team profile card
- Updated title from "Software Engineer II" to "Senior Software Engineer" in authors.yml

**Why?**
Keep the public [Team](https://cadenceworkflow.io/community/team) page aligned with current information.

**How did you verify it?**
Content-only changes, no functional impact.

**Potential risks**
None expected; content-only changes.

**Related changes**
None.