### PR TITLE
fix: Reconfigure algolia settings

### DIFF
--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -83,8 +83,10 @@ jobs:
             echo "ALGOLIA_ADMIN_API_KEY secret not set, skipping re-indexing"
             exit 0
           fi
+          # Pinned to https://hub.docker.com/v2/repositories/algolia/docsearch-scraper/tags/latest
+          # on 2026-04-13, please update this to the latest version occasionally.
           docker run --rm \
             -e APPLICATION_ID \
             -e API_KEY \
             -e "CONFIG=$(cat docsearch-config.json | jq -r tostring)" \
-            algolia/docsearch-scraper
+            algolia/docsearch-scraper@sha256:7bc1cd5aa4783bf24be9ddd6ef22a629b6b43e217b3fa220b6a0acbdeb83b8f8

--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -73,3 +73,18 @@ jobs:
           branch: gh-pages # The branch the action should deploy to.
           folder: build # The folder the action should deploy.
           clean: true # Automatically remove deleted files from the deploy branch
+
+      - name: Re-index Algolia search 🔍
+        env:
+          APPLICATION_ID: N9YD9IU5NA
+          API_KEY: ${{ secrets.ALGOLIA_ADMIN_API_KEY }}
+        run: |
+          if [ -z "$API_KEY" ]; then
+            echo "ALGOLIA_ADMIN_API_KEY secret not set, skipping re-indexing"
+            exit 0
+          fi
+          docker run --rm \
+            -e APPLICATION_ID \
+            -e API_KEY \
+            -e "CONFIG=$(cat docsearch-config.json | jq -r tostring)" \
+            algolia/docsearch-scraper

--- a/docsearch-config.json
+++ b/docsearch-config.json
@@ -1,0 +1,89 @@
+{
+  "index_name": "cadenceworkflow",
+  "start_urls": [
+    {
+      "url": "https://cadenceworkflow.io/docs/",
+      "selectors_key": "lvl0",
+      "variables": {
+        "lvl0": "Docs"
+      }
+    },
+    {
+      "url": "https://cadenceworkflow.io/faq/",
+      "selectors_key": "lvl0",
+      "variables": {
+        "lvl0": "FAQ"
+      }
+    },
+    {
+      "url": "https://cadenceworkflow.io/community/",
+      "selectors_key": "lvl0",
+      "variables": {
+        "lvl0": "Community"
+      }
+    },
+    {
+      "url": "https://cadenceworkflow.io/blog/",
+      "selectors_key": "lvl0",
+      "variables": {
+        "lvl0": "Blog"
+      }
+    },
+    {
+      "url": "https://cadenceworkflow.io/changelog/",
+      "selectors_key": "lvl0",
+      "variables": {
+        "lvl0": "Changelog"
+      }
+    }
+  ],
+  "stop_urls": [
+    "/blog/archive",
+    "/blog/authors",
+    "/blog/tags",
+    "/blog/page/",
+    "/community/tags",
+    "/faq/tags",
+    "/search",
+    "/markdown-page"
+  ],
+  "selectors": {
+    "default": {
+      "lvl0": {
+        "selector": "",
+        "type": "constant",
+        "default_value": "Documentation"
+      },
+      "lvl1": ".theme-doc-breadcrumbs .breadcrumbs__item:last-child .breadcrumbs__link, article h1",
+      "lvl2": "article h2",
+      "lvl3": "article h3",
+      "lvl4": "article h4",
+      "lvl5": "article h5",
+      "text": "article p, article li"
+    }
+  },
+  "selectors_exclude": [
+    ".theme-admonition",
+    ".docusaurus-highlight-code-line",
+    ".table-of-contents"
+  ],
+  "custom_settings": {
+    "separatorsToIndex": "_",
+    "attributesForFaceting": [
+      "language",
+      "version",
+      "type",
+      "docusaurus_tag"
+    ],
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type"
+    ]
+  },
+  "min_indexed_level": 0,
+  "nb_shards": 1
+}

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -94,6 +94,31 @@ const config: Config = {
           trackingID: 'G-W63QD8QE6E',
           anonymizeIP: true,
         },
+        sitemap: {
+          changefreq: 'weekly',
+          createSitemapItems: async (params) => {
+            const {defaultCreateSitemapItems, ...rest} = params;
+            const items = await defaultCreateSitemapItems(rest);
+            return items.map((item) => {
+              if (item.url === 'https://cadenceworkflow.io/') {
+                return {...item, priority: 1.0};
+              }
+              if (item.url.includes('/docs/get-started')) {
+                return {...item, priority: 0.9};
+              }
+              if (item.url.includes('/faq/')) {
+                return {...item, priority: 0.8};
+              }
+              if (item.url.includes('/docs/')) {
+                return {...item, priority: 0.7};
+              }
+              if (item.url.includes('/blog/') && !item.url.includes('/tags') && !item.url.includes('/page/') && !item.url.includes('/authors')) {
+                return {...item, priority: 0.6};
+              }
+              return {...item, priority: 0.5};
+            });
+          },
+        },
       } satisfies Preset.Options,
     ],
   ],

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -172,6 +172,13 @@ const config: Config = {
 
   headTags: [
     {
+      tagName: 'meta',
+      attributes: {
+        name: 'algolia-site-verification',
+        content: '0985E180AA68E235',
+      },
+    },
+    {
       tagName: 'link',
       attributes: {
         rel: 'preload',
@@ -255,10 +262,10 @@ const config: Config = {
 
     algolia: {
       // The application ID provided by Algolia
-      appId: 'J7SVDVT89Z',
+      appId: 'N9YD9IU5NA',
 
       // Public API key: it is safe to commit it
-      apiKey: 'e96333af9178875d6417a55ac276d718',
+      apiKey: 'b1e19704002d5d620299a443771ea84e',
 
       indexName: 'cadenceworkflow',
 


### PR DESCRIPTION
<!-- If you are new to contributing to Cadence-Docs or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Algolia integration was broken which was preventing us have correct SEO settings. This PR attempts to fix it.

**Why?**


**How did you verify it?**


**Potential risks**


**Related changes**

----
## Summary by Gitar

- **Security fix:**
  - Pinned `algolia/docsearch-scraper` Docker image to specific SHA256 digest instead of latest tag
- **Documentation:**
  - Added comment noting pinning date (2026-04-13) with reminder to update version periodically

<sub>This will update automatically on new commits.</sub>