### PR TITLE
fix: Fix Algolia configs

### DIFF
--- a/.github/workflows/publish-to-gh-pages.yml
+++ b/.github/workflows/publish-to-gh-pages.yml
@@ -76,17 +76,13 @@ jobs:
 
       - name: Re-index Algolia search 🔍
         env:
-          APPLICATION_ID: N9YD9IU5NA
-          API_KEY: ${{ secrets.ALGOLIA_ADMIN_API_KEY }}
+          ALGOLIA_CRAWLER_ID: ${{ secrets.ALGOLIA_CRAWLER_ID }}
+          ALGOLIA_CRAWLER_API_KEY: ${{ secrets.ALGOLIA_CRAWLER_API_KEY }}
         run: |
-          if [ -z "$API_KEY" ]; then
-            echo "ALGOLIA_ADMIN_API_KEY secret not set, skipping re-indexing"
+          if [ -z "$ALGOLIA_CRAWLER_ID" ] || [ -z "$ALGOLIA_CRAWLER_API_KEY" ]; then
+            echo "ALGOLIA_CRAWLER_ID or ALGOLIA_CRAWLER_API_KEY secret not set, skipping re-indexing"
             exit 0
           fi
-          # Pinned to https://hub.docker.com/v2/repositories/algolia/docsearch-scraper/tags/latest
-          # on 2026-04-13, please update this to the latest version occasionally.
-          docker run --rm \
-            -e APPLICATION_ID \
-            -e API_KEY \
-            -e "CONFIG=$(cat docsearch-config.json | jq -r tostring)" \
-            algolia/docsearch-scraper@sha256:7bc1cd5aa4783bf24be9ddd6ef22a629b6b43e217b3fa220b6a0acbdeb83b8f8
+          curl -X POST "https://crawler.algolia.com/api/1/crawlers/${ALGOLIA_CRAWLER_ID}/reindex" \
+            --user "${ALGOLIA_CRAWLER_API_KEY}:" \
+            --fail

--- a/docsearch-config.local.json
+++ b/docsearch-config.local.json
@@ -1,10 +1,10 @@
 {
   "index_name": "cadenceworkflow",
   "start_urls": [
-    "https://cadenceworkflow.io/"
+    "http://host.docker.internal:3000/"
   ],
   "sitemap_urls": [
-    "https://cadenceworkflow.io/sitemap.xml"
+    "http://host.docker.internal:3000/sitemap.xml"
   ],
   "sitemap_alternate_links": true,
   "stop_urls": [


### PR DESCRIPTION
<!-- If you are new to contributing to Cadence-Docs or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Internal search is working now 

**Why?**


**How did you verify it?**


**Potential risks**


**Related changes**

----
## Summary by Gitar

- **Configuration updates:**
  - Simplified `start_urls` to single domain with sitemap-based crawling via `sitemap_urls`
  - Converted `lvl0` selector from constant value to XPath-based active navigation detection
  - Added table cell selector to text extraction (`article td:last-child`)
- **New local config:**
  - Created `docsearch-config.local.json` for local development with Docker host URL
- **Workflow migration:**
  - Replaced Docker-based docsearch-scraper with Algolia Crawler API for re-indexing
  - Updated secrets from `ALGOLIA_ADMIN_API_KEY` to `ALGOLIA_CRAWLER_ID` and `ALGOLIA_CRAWLER_API_KEY`

<sub>This will update automatically on new commits.</sub>