### PR TITLE
docs(concepts): add workflow engine and open source workflow engine pages

### DIFF
--- a/docs/03-concepts/12-workflow-engine.md
+++ b/docs/03-concepts/12-workflow-engine.md
@@ -1,0 +1,242 @@
+---
+layout: default
+title: Workflow Engine and Workflow Orchestration
+description: Cadence is an open-source, fault-tolerant workflow engine for orchestrating long-running distributed applications. Learn how it compares to queues, databases, and other orchestration platforms.
+keywords:
+  - workflow engine
+  - workflow orchestration
+  - distributed workflow engine
+  - workflow orchestration platform
+  - open source orchestration
+  - cadence workflow
+  - fault tolerant workflow
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Cadence is a fault-tolerant, stateful workflow engine for orchestrating long-running distributed applications. It replaces the patchwork of databases, queues, cron jobs, and microservice glue code that most teams use today to coordinate multi-step business processes — replacing it with plain code.
+
+A workflow in Cadence is a durable function. It can run for seconds or years, survive server restarts, retry failed downstream calls automatically, and receive external events — all without the developer managing any of that infrastructure. Cadence handles durability, retries, timeouts, and state recovery transparently, so the business logic stays in one place.
+
+---
+
+## What a workflow engine does
+
+A workflow engine moves a process through a defined sequence of steps while guaranteeing that every step eventually completes, failures are retried, and the current state is always recoverable. Without a dedicated engine, teams typically stitch this together from several systems.
+
+| Capability | Ad hoc queue + DB approach | Cadence workflow engine |
+|---|---|---|
+| Durable state across steps | Rows in a database, updated by each worker | Implicit — Cadence replays event history automatically |
+| Retry on failure | Custom retry logic per task, often inconsistent | Built-in exponential retry with configurable policy per activity |
+| Long-running timers | External timer service or cron + DB polling | `workflow.Sleep()` — sleeps for minutes or years, no polling |
+| Event-driven branching | Pull from queue, check DB state, route | `workflow.GetSignalChannel()` — receive signals directly in workflow code |
+| Visibility into running processes | Query multiple tables and join | Query workflow state directly via the Cadence UI or API |
+| Compensation (saga rollback) | Hand-rolled, easy to get wrong | Activities are cancellable; saga pattern is a few lines of Go or Java |
+| Scalability | Each component scales independently; coordination is the bottleneck | Horizontal workers; Cadence cluster handles millions of open workflows |
+
+---
+
+## How Cadence differs from queue + database patterns
+
+The standard alternative to a workflow engine is to center coordination around a database and a message queue. A worker polls a queue, executes an action, updates a row, and pushes downstream messages. This works for simple flows, but it fractures state across tables, makes the execution history invisible, and turns every failure scenario into a bespoke retry loop.
+
+Cadence takes a different approach. The entire process — its state, timer, retries, and event handling — lives in a single durable function called a workflow. The Cadence server persists a log of every event the workflow produces. When a worker dies and restarts, the server replays that log to reconstruct the exact in-memory state of the workflow. The developer never writes checkpoint or recovery code.
+
+The subscription management example below illustrates the difference. The full business logic — charge a customer monthly, handle cancellation, send emails — fits in a single function. If the billing service goes down for two days, the workflow simply waits. When the service recovers, execution resumes exactly where it stopped.
+
+<Tabs groupId="lang">
+<TabItem value="go" label="Go">
+
+```go
+func SubscriptionWorkflow(ctx workflow.Context, customerID string) error {
+    ao := workflow.ActivityOptions{
+        ScheduleToCloseTimeout: time.Minute,
+        RetryPolicy: &cadence.RetryPolicy{
+            InitialInterval:    time.Second,
+            BackoffCoefficient: 2,
+            MaximumInterval:    time.Hour,
+        },
+    }
+    ctx = workflow.WithActivityOptions(ctx, ao)
+
+    if err := workflow.ExecuteActivity(ctx, SendWelcomeEmail, customerID).Get(ctx, nil); err != nil {
+        return err
+    }
+
+    cancelCh := workflow.GetSignalChannel(ctx, "cancel")
+
+    for i := 0; i < MaxBillingPeriods; i++ {
+        selector := workflow.NewSelector(ctx)
+        var cancelled bool
+
+        selector.AddReceive(cancelCh, func(c workflow.Channel, ok bool) {
+            cancelled = true
+        })
+        selector.AddFuture(workflow.NewTimer(ctx, BillingPeriod), func(f workflow.Future) {})
+        selector.Select(ctx)
+
+        if cancelled {
+            return workflow.ExecuteActivity(ctx, SendCancellationEmail, customerID).Get(ctx, nil)
+        }
+        if err := workflow.ExecuteActivity(ctx, ChargeCustomer, customerID, i).Get(ctx, nil); err != nil {
+            return err
+        }
+    }
+    return workflow.ExecuteActivity(ctx, SendSubscriptionOverEmail, customerID).Get(ctx, nil)
+}
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+public class SubscriptionWorkflowImpl implements SubscriptionWorkflow {
+
+    private boolean cancelled = false;
+    private final SubscriptionActivities activities =
+        Workflow.newActivityStub(SubscriptionActivities.class,
+            new ActivityOptions.Builder()
+                .setScheduleToCloseTimeout(Duration.ofMinutes(1))
+                .setRetryOptions(new RetryOptions.Builder()
+                    .setInitialInterval(Duration.ofSeconds(1))
+                    .setBackoffCoefficient(2)
+                    .setMaximumInterval(Duration.ofHours(1))
+                    .build())
+                .build());
+
+    @Override
+    public void manageSubscription(String customerId) {
+        activities.sendWelcomeEmail(customerId);
+
+        for (int i = 0; i < MAX_BILLING_PERIODS; i++) {
+            Workflow.await(BILLING_PERIOD, () -> cancelled);
+
+            if (cancelled) {
+                activities.sendCancellationEmail(customerId);
+                return;
+            }
+            activities.chargeCustomer(customerId, i);
+        }
+        activities.sendSubscriptionOverEmail(customerId);
+    }
+
+    @Override
+    public void cancelSubscription() {
+        cancelled = true;
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+This is the complete orchestration logic. There is no scheduler, no polling loop, no state machine table, and no hand-rolled retry code.
+
+---
+
+## Core concepts
+
+Cadence is built on four primitives that compose cleanly with each other.
+
+| Concept | What it is | Docs |
+|---|---|---|
+| **Workflow** | A durable, stateful function that defines the process. Survives restarts; code must be deterministic. | [Workflows](/docs/concepts/workflows) |
+| **Activity** | A unit of non-deterministic work (API call, DB write, email send). Retried independently of the workflow. | [Activities](/docs/concepts/activities) |
+| **Task List** | A named queue that routes work to the right pool of workers. | [Task Lists](/docs/concepts/task-lists) |
+| **Worker** | A process that polls a task list, executes workflows and activities, and reports results back to the Cadence server. | [Deployment Topology](/docs/concepts/topology) |
+
+The Cadence server itself is stateless. All durable state is stored in the configured persistence layer (Cassandra, MySQL, or Postgres).
+
+:::caution Workflows must be deterministic
+Workflow code is replayed from its event history every time a worker picks it up. Any non-deterministic call — random numbers, `time.Now()`, direct HTTP requests, file reads — will produce a different result on replay and corrupt the workflow state. Put all side effects in activities. Use `workflow.Now()` and `workflow.Sleep()` instead of the standard library equivalents.
+:::
+
+---
+
+## Starting a workflow
+
+Starting a workflow requires a client pointed at the Cadence frontend service. The call is non-blocking: the client enqueues the workflow and returns a run ID immediately. The worker picks it up asynchronously.
+
+<Tabs groupId="lang">
+<TabItem value="go" label="Go">
+
+```go
+import "go.uber.org/cadence/client"
+
+c, err := client.NewClient(cadenceServiceClient, domain, &client.Options{})
+if err != nil {
+    log.Fatal(err)
+}
+
+we, err := c.StartWorkflow(ctx, client.StartWorkflowOptions{
+    ID:                           "subscription-" + customerID,
+    TaskList:                     "subscription-task-list",
+    ExecutionStartToCloseTimeout: 365 * 24 * time.Hour,
+}, SubscriptionWorkflow, customerID)
+if err != nil {
+    log.Fatal(err)
+}
+log.Printf("started workflow: id=%s run_id=%s", we.ID, we.RunID)
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+WorkflowClient client = WorkflowClient.newInstance(
+    new Thrift2ProtoAdapter(IGrpcServiceStubs.newInstance()),
+    WorkflowClientOptions.newBuilder().setDomain(DOMAIN).build()
+);
+
+WorkflowOptions options = new WorkflowOptions.Builder()
+    .setWorkflowId("subscription-" + customerId)
+    .setTaskList("subscription-task-list")
+    .setExecutionStartToCloseTimeout(Duration.ofDays(365))
+    .build();
+
+SubscriptionWorkflow workflow = client.newWorkflowStub(
+    SubscriptionWorkflow.class, options
+);
+
+// Non-blocking start — returns immediately.
+WorkflowClient.start(workflow::manageSubscription, customerId);
+```
+
+</TabItem>
+</Tabs>
+
+---
+
+## Production topology
+
+A Cadence cluster has four services: **Frontend** (API gateway), **History** (per-workflow state machine), **Matching** (task list routing), and **Worker** (your application code). The first three are operated by the platform team; you only run the Worker.
+
+For deployment options — SQLite for local dev, Docker Compose, Kubernetes Helm chart, or managed cluster — see the [Server Installation guide](/docs/get-started/server-installation).
+
+:::note Cadence has no hard limit on open workflow instances
+The Cadence server is designed for millions of concurrently open workflows. Scalability is a function of your persistence tier and worker count, not the engine itself.
+:::
+
+---
+
+## Use case patterns
+
+Cadence is a general-purpose workflow engine that fits a wide range of distributed application patterns:
+
+- **Service orchestration** — chain microservice calls with automatic retries and saga rollback. [Orchestration →](/docs/use-cases/orchestration)
+- **Periodic execution** — replace cron + DB with a durable timer inside a workflow. [Periodic execution →](/docs/use-cases/periodic-execution)
+- **Event-driven applications** — receive signals from external systems and branch on them inside the workflow. [Event-driven →](/docs/use-cases/event-driven)
+- **Long-running business processes** — subscriptions, multi-day approvals, infrastructure provisioning. [Operational management →](/docs/use-cases/operational-management)
+
+---
+
+## References
+
+- [Workflows](/docs/concepts/workflows) — full reference for workflow semantics, IDs, retries, child workflows
+- [Activities](/docs/concepts/activities) — timeouts, retry policies, heartbeating
+- [Deployment Topology](/docs/concepts/topology) — how Frontend, Matching, History, and Workers interact
+- [Get Started](/docs/get-started) — server installation and HelloWorld samples in Go and Java
+- [Open Source Workflow Engine](/docs/concepts/open-source-workflow-engine) — self-hosting, deployment options, community
+- Go SDK: [go.uber.org/cadence](https://pkg.go.dev/go.uber.org/cadence)
+- Java SDK: [com.uber.cadence](https://javadoc.io/doc/com.uber.cadence/cadence-client)

--- a/docs/03-concepts/15-open-source-workflow-engine.md
+++ b/docs/03-concepts/15-open-source-workflow-engine.md
@@ -94,7 +94,7 @@ The server image `ubercadence/server` is updated with every release. See [Docker
 | Java | Official | [cadence-workflow/cadence-java-client](https://github.com/cadence-workflow/cadence-java-client) |
 | Python | Community | [cadence-workflow/cadence-python](https://github.com/cadence-workflow/cadence-python) |
 | Ruby | Community | [coinbase/cadence-ruby](https://github.com/coinbase/cadence-ruby) |
-| .NET | In development | [cadence-workflow/cadence-dotnet-client](https://github.com/cadence-workflow/cadence-dotnet-client) |
+| .NET | In development | — |
 
 You can also use [iWF](https://github.com/indeedeng/iwf) as a DSL framework that runs on top of Cadence if you prefer a state-machine abstraction over raw workflow code.
 

--- a/docs/03-concepts/15-open-source-workflow-engine.md
+++ b/docs/03-concepts/15-open-source-workflow-engine.md
@@ -92,7 +92,7 @@ The server image `ubercadence/server` is updated with every release. See [Docker
 |---|---|---|
 | Go | Official | [cadence-workflow/cadence-go-client](https://github.com/cadence-workflow/cadence-go-client) |
 | Java | Official | [cadence-workflow/cadence-java-client](https://github.com/cadence-workflow/cadence-java-client) |
-| Python | Community | [cadence-workflow/cadence-python](https://github.com/cadence-workflow/cadence-python) |
+| Python | Community | — |
 | Ruby | Community | [coinbase/cadence-ruby](https://github.com/coinbase/cadence-ruby) |
 | .NET | In development | — |
 

--- a/docs/03-concepts/15-open-source-workflow-engine.md
+++ b/docs/03-concepts/15-open-source-workflow-engine.md
@@ -1,0 +1,191 @@
+---
+layout: default
+title: Open Source Workflow Engine
+description: Cadence is an open-source, self-hostable workflow engine for durable, fault-tolerant distributed applications. Deploy on SQLite, Docker, or Kubernetes. Apache 2.0 licensed and CNCF-hosted.
+keywords:
+  - open source workflow engine
+  - open source workflow orchestration
+  - self hosted workflow engine
+  - open source workflow automation
+  - cadence open source
+  - cadence workflow github
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Cadence is an open-source workflow engine for building fault-tolerant, stateful distributed applications. It is released under the [Apache 2.0 license](https://github.com/cadence-workflow/cadence/blob/master/LICENSE), hosted by the [Linux Foundation](https://lfprojects.org/policies/), and actively maintained by contributors from Uber and the broader open-source community.
+
+The full source — server, Go client, Java client, web UI, and Helm charts — is on [GitHub](https://github.com/cadence-workflow). You can run Cadence on your laptop in under five minutes with a single SQLite binary, or deploy it to Kubernetes with a Helm chart. No license key, no usage limits, no vendor dependency.
+
+---
+
+## Why open source matters for a workflow engine
+
+A workflow engine sits at the center of your most critical business processes. Open source changes the risk profile of that dependency significantly.
+
+| Concern | Proprietary / hosted-only engine | Cadence (open source) |
+|---|---|---|
+| Vendor lock-in | Workflows are tied to a provider's API and pricing | Run anywhere; migrate to your own cluster at any time |
+| Auditability | Black box — you cannot inspect how state is stored or replayed | Full source available; persistence schema is documented and versioned |
+| Data residency | Payloads stored on provider infrastructure | Your workflows stay in your VPC, your region, your storage tier |
+| Customization | Blocked by the provider's feature roadmap | Fork, extend, or contribute upstream |
+| Cost at scale | Per-workflow or per-execution pricing adds up | Operational cost only — no per-execution fee |
+| Community support | Vendor-controlled SLAs | Stack Overflow, CNCF Slack, GitHub Issues, community contributors |
+
+---
+
+## Deployment options
+
+Cadence supports four deployment modes. Start with the simplest one that fits your stage.
+
+| Mode | Backend | When to use |
+|---|---|---|
+| **SQLite** | Embedded SQLite | Local development, demos, CI — no Docker required |
+| **Docker Compose** | Cassandra or MySQL in containers | Team dev environment, local integration tests |
+| **Kubernetes (Helm)** | Cassandra, MySQL, or Postgres | Staging and production |
+| **Managed (Uber)** | Uber-operated multi-tenant cluster | Uber internal teams |
+
+### Local quickstart
+
+SQLite mode requires no Docker and no external database. It is the fastest path from a fresh clone to a running Cadence server.
+
+<Tabs groupId="deployment">
+<TabItem value="sqlite" label="SQLite (no Docker)">
+
+```bash
+git clone https://github.com/cadence-workflow/cadence.git
+cd cadence
+make bins
+make install-schema-sqlite
+./cadence-server --zone sqlite start
+```
+
+Open `http://localhost:8088` for the Cadence Web UI.
+
+</TabItem>
+<TabItem value="docker" label="Docker Compose">
+
+```bash
+git clone https://github.com/cadence-workflow/cadence.git
+cd cadence/docker
+
+# Starts Cadence + Cassandra
+docker-compose up
+
+# Or use the MySQL variant
+docker-compose -f docker-compose-mysql.yml up
+```
+
+</TabItem>
+</Tabs>
+
+:::note Pre-built Docker images are available on Docker Hub
+The server image `ubercadence/server` is updated with every release. See [Docker Hub](https://hub.docker.com/r/ubercadence/server).
+:::
+
+---
+
+## Client SDKs
+
+| Language | Status | Repository |
+|---|---|---|
+| Go | Official | [cadence-workflow/cadence-go-client](https://github.com/cadence-workflow/cadence-go-client) |
+| Java | Official | [cadence-workflow/cadence-java-client](https://github.com/cadence-workflow/cadence-java-client) |
+| Python | Community | [cadence-workflow/cadence-python](https://github.com/cadence-workflow/cadence-python) |
+| Ruby | Community | [coinbase/cadence-ruby](https://github.com/coinbase/cadence-ruby) |
+| .NET | In development | [cadence-workflow/cadence-dotnet-client](https://github.com/cadence-workflow/cadence-dotnet-client) |
+
+You can also use [iWF](https://github.com/indeedeng/iwf) as a DSL framework that runs on top of Cadence if you prefer a state-machine abstraction over raw workflow code.
+
+---
+
+## Hello World
+
+The smallest possible Cadence program registers a workflow, registers an activity, starts a worker, and runs the workflow from a client.
+
+<Tabs groupId="lang">
+<TabItem value="go" label="Go">
+
+```go
+func HelloWorkflow(ctx workflow.Context, name string) (string, error) {
+    ao := workflow.ActivityOptions{ScheduleToCloseTimeout: 10 * time.Second}
+    ctx = workflow.WithActivityOptions(ctx, ao)
+
+    var result string
+    err := workflow.ExecuteActivity(ctx, HelloActivity, name).Get(ctx, &result)
+    return result, err
+}
+
+func HelloActivity(ctx context.Context, name string) (string, error) {
+    return "Hello, " + name + "!", nil
+}
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+public interface HelloWorkflow {
+    @WorkflowMethod
+    String sayHello(String name);
+}
+
+public class HelloWorkflowImpl implements HelloWorkflow {
+    private final HelloActivities activities =
+        Workflow.newActivityStub(HelloActivities.class);
+
+    @Override
+    public String sayHello(String name) {
+        return activities.greet(name);
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Full step-by-step guides: [Golang Hello World](/docs/get-started/golang-hello-world) · [Java Hello World](/docs/get-started/java-hello-world)
+
+:::caution Register workflows and activities on every worker
+Every worker that polls a task list must register all workflows and activities that may run on that task list. A worker that receives a task for an unregistered type will abandon the task and block the workflow until a correctly registered worker picks it up.
+:::
+
+---
+
+## Persistence backends
+
+| Backend | Production use | Notes |
+|---|---|---|
+| **Cassandra** | Yes | Recommended for high-throughput, multi-region deployments |
+| **MySQL 8** | Yes | Simpler ops for teams already running MySQL |
+| **Postgres** | Yes | Fully supported; schema in `schema/postgres/` |
+| **SQLite** | Local dev only | Embedded, zero-config; not for production |
+
+Schema migrations are managed by the `cadence-sql-tool` CLI bundled with the server binary. See [CONTRIBUTING.md](https://github.com/cadence-workflow/cadence/blob/master/CONTRIBUTING.md) for setup instructions.
+
+---
+
+## Community
+
+| Channel | Link |
+|---|---|
+| CNCF Slack (`#cadence-workflow`) | [Join](https://slack.cncf.io/) |
+| Stack Overflow | [`cadence-workflow` tag](https://stackoverflow.com/questions/tagged/cadence-workflow) |
+| GitHub Issues | [cadence-workflow/cadence/issues](https://github.com/cadence-workflow/cadence/issues) |
+| GitHub Discussions | [cadence-workflow/cadence/discussions](https://github.com/cadence-workflow/cadence/discussions) |
+| Reddit | [r/cadenceworkflow](https://www.reddit.com/r/cadenceworkflow/) |
+| OSS Community Survey | [2025 Survey](https://lf.biz/cadence-survey-2025) |
+
+Contributions to the server, SDKs, docs, and samples are welcome. See [CONTRIBUTING.md](https://github.com/cadence-workflow/cadence/blob/master/CONTRIBUTING.md) for the development setup, coding standards, and PR process.
+
+---
+
+## References
+
+- [Workflow Engine and Orchestration](/docs/concepts/workflow-engine) — how Cadence works as a workflow engine
+- [Get Started](/docs/get-started) — server installation, HelloWorld samples, Video Tutorials
+- [Deployment Topology](/docs/concepts/topology) — Frontend, Matching, History, Worker services
+- GitHub org: [github.com/cadence-workflow](https://github.com/cadence-workflow)
+- Docker Hub: [ubercadence/server](https://hub.docker.com/r/ubercadence/server)
+- Helm charts: [cadence-workflow/cadence-charts](https://github.com/cadence-workflow/cadence-charts)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -64,6 +64,8 @@ const sidebars: SidebarsConfig = {
         { type: 'doc', id: 'concepts/http-api' },
         { type: 'doc', id: 'concepts/data-converter' },
         { type: 'doc', id: 'concepts/workflow-queries-formatted-data' },
+        { type: 'doc', id: 'concepts/workflow-engine' },
+        { type: 'doc', id: 'concepts/open-source-workflow-engine' },
       ],
     },
     {


### PR DESCRIPTION
**What changed?**

Added two new concept pages: \`docs/concepts/workflow-engine\` (what a workflow engine is and why it exists) and \`docs/concepts/open-source-workflow-engine\` (how Cadence compares to alternatives). Both pages are registered in \`sidebars.ts\` under the Concepts section.

**Why?**

The Concepts section had no page answering the foundational question "what is a workflow engine?" — a query many first-time visitors bring. Without that anchor page, traffic landing from workflow-engine searches had nowhere to go in the Cadence docs. These pages give that traffic a home and provide CTAs back to Get Started.

**How did you verify it?**

\`npm run build\` — clean build, no broken link or sidebar errors.
\`npm run start\` — verified \`/docs/concepts/workflow-engine\` and \`/docs/concepts/open-source-workflow-engine\` render correctly and appear in the Concepts sidebar.
\`npm run preview:github-pages -- --serve\` — confirmed both pages render correctly in dark and light mode.

- [x] Ran production preview (\`npm run preview:github-pages -- --serve\`)
- [x] Checked dark mode and light mode on affected pages

**Potential risks**

The two pages are appended after \`concepts/workflow-queries-formatted-data\` in the sidebar. If a different position is preferred that is a one-line change.

**Related changes**

PR #351 (\`docs(get-started)\`) links to these pages from the Get Started What's Next table — merge this PR first.