### PR TITLE
fix(concepts): correct ScheduleToCloseTimeout in subscription workflow example

### DIFF
--- a/docs/03-concepts/12-workflow-engine.md
+++ b/docs/03-concepts/12-workflow-engine.md
@@ -51,7 +51,7 @@ The subscription management example below illustrates the difference. The full b
 ```go
 func SubscriptionWorkflow(ctx workflow.Context, customerID string) error {
     ao := workflow.ActivityOptions{
-        ScheduleToCloseTimeout: time.Minute,
+        ScheduleToCloseTimeout: 3 * 24 * time.Hour,
         RetryPolicy: &cadence.RetryPolicy{
             InitialInterval:    time.Second,
             BackoffCoefficient: 2,
@@ -97,7 +97,7 @@ public class SubscriptionWorkflowImpl implements SubscriptionWorkflow {
     private final SubscriptionActivities activities =
         Workflow.newActivityStub(SubscriptionActivities.class,
             new ActivityOptions.Builder()
-                .setScheduleToCloseTimeout(Duration.ofMinutes(1))
+                .setScheduleToCloseTimeout(Duration.ofDays(3))
                 .setRetryOptions(new RetryOptions.Builder()
                     .setInitialInterval(Duration.ofSeconds(1))
                     .setBackoffCoefficient(2)


### PR DESCRIPTION
**What changed?**

`ScheduleToCloseTimeout` in the Go and Java subscription workflow snippets updated from 1 minute to 3 days.

**Why?**

The surrounding prose describes a scenario where the billing service is down for two days and the workflow waits — but a 1-minute `ScheduleToCloseTimeout` would terminate the activity (including all retries) well before that. Spotted by @Bueller87 in PR #350.

**How did you verify it?**

`npm run build` — clean build, no broken link or sidebar errors.
`npm run start` — verified `/docs/concepts/workflow-engine` renders correctly with the updated code snippets in both Go and Java tabs.

**Potential risks**

None. This is a two-line change to code snippet values inside a markdown file. No prose, structure, or frontmatter is affected.

**Related changes**

Addresses review comment from PR #350: https://github.com/cadence-workflow/Cadence-Docs/pull/350
