### PR TITLE
seo(concepts): add Go workflow engine keywords and section to workflow engine pages

### DIFF
--- a/docs/03-concepts/12-workflow-engine.md
+++ b/docs/03-concepts/12-workflow-engine.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Workflow Engine and Workflow Orchestration
-description: Cadence is an open-source, fault-tolerant workflow engine for orchestrating long-running distributed applications. Learn how it compares to queues, databases, and other orchestration platforms.
+description: Cadence is an open-source workflow engine for Go, Java, and Python — fault-tolerant, stateful, and built for long-running distributed applications. Learn how it compares to queues, cron jobs, and state machines.
 keywords:
   - workflow engine
   - workflow orchestration
@@ -10,6 +10,14 @@ keywords:
   - open source orchestration
   - cadence workflow
   - fault tolerant workflow
+  - go workflow engine
+  - golang workflow engine
+  - workflow engine golang
+  - go workflow orchestration
+  - golang workflow orchestration
+  - workflow engine go sdk
+  - embeddable workflow engine
+  - embedded workflow engine
 ---
 
 import Tabs from '@theme/Tabs';
@@ -230,6 +238,27 @@ Cadence is a general-purpose workflow engine that fits a wide range of distribut
 - **Long-running business processes** — subscriptions, multi-day approvals, infrastructure provisioning. [Operational management →](/docs/use-cases/operational-management)
 
 ---
+
+## Using Cadence as your Go or Java workflow engine
+
+Cadence has first-class SDKs for Go and Java, with Python and TypeScript clients in active development.
+
+The Go SDK (`go.uber.org/cadence`) is the most widely used in production. A Cadence worker is an ordinary Go binary that calls `worker.New()` and registers your workflow and activity functions. There is no special runtime, no sidecar, and no DSL — workflows are plain Go functions that happen to be durable.
+
+```go
+// A minimal Go worker that registers one workflow and starts polling.
+w := worker.New(service, domain, taskList, worker.Options{})
+w.RegisterWorkflow(SubscriptionWorkflow)
+w.RegisterActivity(ChargeCustomer)
+w.Start()
+```
+
+Workers can be embedded in existing Go services or run as standalone binaries alongside your application. The Cadence server is the only external dependency — all workflow state is stored server-side.
+
+For language-specific guides:
+- [Go SDK — Workers](/docs/go-client/workers)
+- [Go SDK — Creating Workflows](/docs/go-client/create-workflows)
+- [Java SDK — Workflows](/docs/java-client/workflow-interface)
 
 ## References
 

--- a/docs/05-go-client/01-workers.md
+++ b/docs/05-go-client/01-workers.md
@@ -10,6 +10,10 @@ keywords:
   - cadence tchannel worker
   - go cadence worker example
   - cadence worker setup go
+  - go workflow engine
+  - golang workflow engine
+  - workflow engine go
+  - embedded workflow engine go
 permalink: /docs/go-client/workers
 ---
 


### PR DESCRIPTION
**What changed?**

Updated `docs/03-concepts/12-workflow-engine.md` and `docs/05-go-client/01-workers.md` to target Go-specific workflow engine queries that rank at position 11–12 but earn zero clicks.

**Why?**

GSC data shows these queries hovering just off page 1 with no clicks:
- "go workflow engine" — 51 impressions, position 11.43, **0% CTR**
- "golang workflow engine" — 37 impressions, position 11.84, **0% CTR**
- "embeddable workflow engine" — 55 impressions, position 55.04, **0% CTR**
- "embedded workflow engine" — 49 impressions, position 65.76, **0% CTR**

The workflow engine concept page already had Go code examples but never named itself as a "Go workflow engine" in metadata or content. The workers page had no workflow-engine framing at all.

Changes to `docs/03-concepts/12-workflow-engine.md`:
- **Description**: updated to explicitly mention Go, Java, and Python SDKs
- **Keywords**: added `go workflow engine`, `golang workflow engine`, `workflow engine golang`, `embeddable workflow engine`, `embedded workflow engine`, and 3 more variants
- **New section**: "Using Cadence as your Go or Java workflow engine" — explains that a worker is a plain Go binary, shows a 6-line minimal worker snippet, and links to the SDK guides. Covers the embedded/embeddable use case.

Changes to `docs/05-go-client/01-workers.md`:
- **Keywords**: added `go workflow engine`, `golang workflow engine`, `workflow engine go`, `embedded workflow engine go`

**How did you verify it?**

`npm run build` — clean build, no broken link or sidebar errors.
`npm run start` — verified `/docs/concepts/workflow-engine` renders correctly with the new section and code snippet.

- Ran production preview (`npm run preview:github-pages -- --serve`)
- Checked dark mode and light mode on affected pages

**Potential risks**

New section adds a Go code snippet. The snippet uses the standard `go.uber.org/cadence` worker API — no new dependencies or imports needed.

**Related changes**

Part of a 2-PR SEO push. The companion PR (#354) targets the comparison/alternatives query cluster.

Made with [Cursor](https://cursor.com)