### PR TITLE
docs(concepts): add Go SDK section and keywords to workflow engine page

### DIFF
--- a/docs/03-concepts/12-workflow-engine.md
+++ b/docs/03-concepts/12-workflow-engine.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Workflow Engine and Workflow Orchestration
-description: Cadence is an open-source, fault-tolerant workflow engine for orchestrating long-running distributed applications. Learn how it compares to queues, databases, and other orchestration platforms.
+description: Cadence is an open-source workflow engine for Go, Java, and Python — fault-tolerant, stateful, and built for long-running distributed applications. Learn how it compares to queues, cron jobs, and state machines.
 keywords:
   - workflow engine
   - workflow orchestration
@@ -10,6 +10,13 @@ keywords:
   - open source orchestration
   - cadence workflow
   - fault tolerant workflow
+  - go workflow engine
+  - golang workflow engine
+  - workflow engine golang
+  - go workflow orchestration
+  - golang workflow orchestration
+  - embeddable workflow engine
+  - embedded workflow engine
 ---
 
 import Tabs from '@theme/Tabs';
@@ -230,6 +237,27 @@ Cadence is a general-purpose workflow engine that fits a wide range of distribut
 - **Long-running business processes** — subscriptions, multi-day approvals, infrastructure provisioning. [Operational management →](/docs/use-cases/operational-management)
 
 ---
+
+## Using Cadence as your Go or Java workflow engine
+
+Cadence has first-class SDKs for Go and Java, with Python and TypeScript clients in active development.
+
+The Go SDK (`go.uber.org/cadence`) is the most widely used in production. A Cadence worker is an ordinary Go binary that calls `worker.New()` and registers your workflow and activity functions. There is no special runtime, no sidecar, and no DSL — workflows are plain Go functions that happen to be durable.
+
+```go
+// A minimal Go worker registering one workflow and one activity.
+w := worker.New(service, domain, taskList, worker.Options{})
+w.RegisterWorkflow(SubscriptionWorkflow)
+w.RegisterActivity(ChargeCustomer)
+w.Start()
+```
+
+Workers can be embedded in existing Go services or run as standalone binaries. The Cadence server is the only external dependency — all workflow state is stored server-side.
+
+For language-specific guides:
+- [Go SDK — Workers](/docs/go-client/workers)
+- [Go SDK — Creating Workflows](/docs/go-client/create-workflows)
+- [Java SDK — Workflows](/docs/java-client/workflow-interface)
 
 ## References
 

--- a/docs/05-go-client/01-workers.md
+++ b/docs/05-go-client/01-workers.md
@@ -10,6 +10,10 @@ keywords:
   - cadence tchannel worker
   - go cadence worker example
   - cadence worker setup go
+  - go workflow engine
+  - golang workflow engine
+  - workflow engine go
+  - embedded workflow engine go
 permalink: /docs/go-client/workers
 ---
 


### PR DESCRIPTION
**What changed?**

Updated \`docs/03-concepts/12-workflow-engine.md\`:
- Meta description updated to explicitly name Go, Java, and Python SDKs — the previous description mentioned none of them
- Keywords expanded to include Go-specific variants: \`go workflow engine\`, \`golang workflow engine\`, \`workflow engine golang\`, \`embeddable workflow engine\`, \`embedded workflow engine\`
- New section: \"Using Cadence as your Go or Java workflow engine\" — a short section (6-lminimal worker snippet + 3 SDK links) that explains how Cadence workers embed in Go services. Bridges the concept page to the Go and Java SDK guides without duplicating them

Updated \`docs/05-go-client/01-workers.md\`:
- Keywords expanded with \`go workflow engine\`, \`golang workflow engine\`, \`workflow engine go\`, \`embedded workflow engine go\`

**Why?**

The workflow engine concept page had Go code examples throughout but never identified itself as a Go workflow engine in its metadata or content. Developers coming from Go-specific searches landed on the page but had no explicit bridge to the Go SDK docs. The new section fills that gap and links to the workers and create-workflows guides.

The workers page had no workflow-engine framing in its keywords despite being the canonical entry point for Go developers setting up Cadence.

**How did you verify it?**

\`npm run build\` — clean build, no broken link or sidebar errors.
\`npm run start\` — verified \`/docs/concepts/workflow-engine\` renders correctly with the new section and code snippet.

- Ran production preview (\`npm run preview:github-pages -- --serve\`)
- Checked dark mode and light mode on affected pages

**Potential risks**

The new Go snippet uses the standard \`go.uber.org/cadence\` worker API already used throughout the docs. No new imports or dependencies.

**Related changes**

Companion PR improves the Cadence vs Temporal comparison page.