### PR TITLE
docs: add durable execution framing, FAQ, and Temporal migration guide

### DIFF
--- a/docs/02-use-cases/index.md
+++ b/docs/02-use-cases/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Introduction
-description: This page introduces the range of use cases where Cadence excels, from orchestration and periodic execution to event-driven systems and ML pipelines.
+description: Cadence is a durable execution engine that replaces ad-hoc combinations of queues, cron jobs, and databases. Explore the use cases where it fits best.
 keywords:
   - cadence use cases
   - cadence applications
@@ -10,8 +10,15 @@ keywords:
   - cadence distributed application
   - cadence durable function
   - cadence orchestration
+  - durable execution use cases
+  - workflow engine use cases
+  - when to use a workflow engine
 permalink: /docs/use-cases/
 ---
+
+# Use Cases
+
+Cadence shines anywhere your business logic spans more than a single request-response cycle — long-running processes, multi-step orchestration, retry-heavy integrations, or anything that today lives in a fragile combination of cron jobs, queues, and database polling. The durable execution model replaces that infrastructure with plain application code that Cadence keeps running reliably.
 
 As Cadence developers, we face a difficult non-technical problem: How to position and describe the Cadence platform.
 

--- a/docs/03-concepts/01-workflows.md
+++ b/docs/03-concepts/01-workflows.md
@@ -1,22 +1,26 @@
 ---
 layout: default
 title: Workflows
-description: This page explains the Cadence workflow abstraction, a fault-oblivious stateful function that encapsulates state, timers, and event handlers across failures and restarts.
+description: Cadence workflows are durable execution functions — code that runs as ordinary application logic but survives process restarts, failures, and long pauses without any extra infrastructure.
 keywords:
   - cadence workflow
   - cadence workflow concept
+  - durable execution
+  - durable execution model
   - fault-oblivious workflow
   - stateful workflow
   - cadence durable function
   - cadence workflow definition
   - cadence workflow example
+  - durable workflow
 permalink: /docs/concepts/workflows
 ---
 
-## Overview
+# Workflows
 
-Cadence core abstraction is a **fault-oblivious stateful :workflow:**. The state of the :workflow: code, including local variables and threads it creates, is immune to process and Cadence service failures.
-This is a very powerful concept as it encapsulates state, processing threads, durable timers and :event: handlers.
+The central abstraction in Cadence is a **durable execution function** — ordinary application code that continues running correctly across process restarts, infrastructure failures, and arbitrary pauses. You write it as a plain function; Cadence handles making it durable.
+
+More precisely, Cadence calls this a **fault-oblivious stateful :workflow:**. The state of the :workflow: code, including local variables and threads it creates, is immune to process and Cadence service failures. This is a very powerful concept as it encapsulates state, processing threads, durable timers and :event: handlers.
 
 ## Example
 

--- a/faq/cadence-faq.mdx
+++ b/faq/cadence-faq.mdx
@@ -1,0 +1,65 @@
+---
+layout: default
+title: Cadence FAQ
+description: Answers to common questions about Cadence — what it is, how workflows and activities differ, how failures are handled, and when to use it instead of a message queue.
+keywords:
+  - cadence faq
+  - cadence questions
+  - workflow vs activity
+  - cadence vs message queue
+  - cadence vs kafka
+  - cadence vs sqs
+  - how does cadence handle failures
+  - cadence durable execution
+  - what is cadence workflow
+  - when to use cadence
+permalink: /faq/cadence-faq
+---
+
+# Cadence FAQ
+
+## What is Cadence?
+
+Cadence is a durable execution engine. You write business logic as ordinary code — functions that call services, sleep for days, retry on failure — and Cadence makes that code survive process crashes, restarts, and infrastructure outages without you adding any extra state management.
+
+Think of it as a runtime that keeps your code running reliably across failures, not a framework that requires you to restructure your logic around queues, state machines, or cron jobs.
+
+## What's the difference between a workflow and an activity?
+
+A **workflow** is the durable orchestration function. It defines the sequence and control flow of your business process. Workflow code must be deterministic — it cannot make network calls, read from the filesystem, or use real-world time directly, because Cadence may replay it to reconstruct state after a failure.
+
+An **activity** is where the actual work happens — API calls, database writes, sending emails. Activities run in your application code, are retried automatically on failure, and can be as long-running as needed. They are not subject to the determinism constraint.
+
+A simple rule of thumb: if it touches the outside world, it's an activity. If it decides what to do next, it's in the workflow.
+
+## When should I use Cadence instead of a message queue (Kafka, SQS, RabbitMQ)?
+
+Message queues are great for point-to-point async delivery. They become painful when your process:
+
+- Spans multiple steps with dependencies between them
+- Needs to retry individual steps with backoff and a deadline
+- Has to wait minutes, hours, or days between steps
+- Must track overall progress or handle partial failures across steps
+- Requires exactly-once semantics across service boundaries
+
+In those cases you end up writing a lot of glue code on top of the queue — polling tables for status, building state machines, writing retry logic. Cadence replaces that glue code with a plain function.
+
+For simple fire-and-forget fanout or high-throughput streaming, a queue is usually the right tool.
+
+## How does Cadence handle failures?
+
+At the workflow level, Cadence automatically resumes execution from where it left off after any infrastructure failure — worker crash, server restart, network partition. Your workflow code sees none of it; execution continues as if nothing happened.
+
+At the activity level, Cadence retries failed activities according to the retry policy you configure (initial interval, backoff coefficient, max attempts, expiration). If an activity exceeds its retry budget, the error is surfaced to the workflow where your code can handle or escalate it.
+
+The only failure that actually terminates a workflow is an unhandled error thrown by your own business logic.
+
+## Can a workflow run for a very long time?
+
+Yes. Cadence workflows can run for years. The state is persisted to the database at every step, so the workflow can be paused (e.g. waiting on a timer or a signal) without consuming any compute resources, and resume exactly where it left off.
+
+If the event history grows very large over time, use [Continue-as-New](/docs/go-client/continue-as-new) to checkpoint and restart the workflow with a clean history.
+
+## What's the difference between Cadence and Temporal?
+
+Temporal is a 2019 fork of Cadence. They share the same core execution model but have diverged since. See the [Cadence vs Temporal](/faq/cadence-vs-temporal) page for a detailed comparison.

--- a/faq/migrate-from-temporal.mdx
+++ b/faq/migrate-from-temporal.mdx
@@ -1,0 +1,171 @@
+---
+layout: default
+title: Migrating from Temporal to Cadence
+description: Practical guide for migrating Go or Java applications from Temporal to Cadence — SDK package mapping, concept renames, and client setup differences.
+keywords:
+  - migrate from temporal to cadence
+  - temporal to cadence migration
+  - temporal cadence sdk differences
+  - cadence temporal sdk comparison
+  - temporal namespace cadence domain
+  - temporal taskqueue cadence tasklist
+  - cadence go sdk migration
+  - cadence java sdk migration
+permalink: /faq/migrate-from-temporal
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Migrating from Temporal to Cadence
+
+Cadence and Temporal share the same durable execution model — Temporal is a 2019 fork of Cadence. Core concepts map directly, but the two projects have diverged in naming conventions, SDK packages, and client setup. This page covers what needs to change when moving a Go or Java application from Temporal to Cadence.
+
+## Concept mapping
+
+| Temporal | Cadence | Notes |
+|---|---|---|
+| Namespace | Domain | Top-level isolation boundary for workflows |
+| TaskQueue | TaskList | Routes work to the right workers |
+| Worker | Worker | Same concept, different SDK packages |
+| Workflow | Workflow | Same concept |
+| Activity | Activity | Same concept |
+| Signal | Signal | Same concept |
+| Query | Query | Same concept |
+| Schedule | CronSchedule / DistributedCron | Cadence uses `CronSchedule` on workflow options or the [distributed cron pattern](/docs/go-client/distributed-cron) |
+| `workflow.GetLogger` | `workflow.GetLogger` | Same API |
+| `temporal.io/sdk` | `go.uber.org/cadence` | Go package root |
+| `io.temporal` | `com.uber.cadence` | Java package root |
+
+## Go SDK
+
+### Package imports
+
+```go
+// Temporal
+import (
+    "go.temporal.io/sdk/client"
+    "go.temporal.io/sdk/worker"
+    "go.temporal.io/sdk/workflow"
+    "go.temporal.io/sdk/activity"
+)
+
+// Cadence
+import (
+    "go.uber.org/cadence/client"
+    "go.uber.org/cadence/worker"
+    "go.uber.org/cadence/workflow"
+    "go.uber.org/cadence/activity"
+)
+```
+
+### Client setup
+
+Cadence uses [YARPC](https://github.com/yarpc/yarpc-go) for transport rather than gRPC. The client setup is different:
+
+```go
+// Cadence
+import (
+    "go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
+    "go.uber.org/yarpc"
+    "go.uber.org/yarpc/transport/tchannel"
+)
+
+ch, _ := tchannel.NewChannelTransport(tchannel.ServiceName("cadence-client"))
+dispatcher := yarpc.NewDispatcher(yarpc.Config{
+    Name: "cadence-client",
+    Outbounds: yarpc.Outbounds{
+        "cadence-frontend": {Unary: ch.NewSingleOutbound("127.0.0.1:7933")},
+    },
+})
+dispatcher.Start()
+
+cadenceClient := workflowserviceclient.New(dispatcher.ClientConfig("cadence-frontend"))
+c, _ := client.NewClient(cadenceClient, "your-domain", &client.Options{})
+```
+
+### Starting a workflow
+
+```go
+// Temporal
+options := client.StartWorkflowOptions{
+    TaskQueue: "my-task-queue",
+}
+
+// Cadence
+options := client.StartWorkflowOptions{
+    TaskList: "my-task-list",
+}
+```
+
+### Worker registration
+
+```go
+// Temporal
+w := worker.New(c, "my-task-queue", worker.Options{})
+
+// Cadence
+w := worker.New(cadenceClient, "your-domain", "my-task-list", worker.Options{})
+```
+
+Note that the Cadence worker constructor takes the domain name as an explicit argument.
+
+## Java SDK
+
+### Package imports
+
+```java
+// Temporal
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.worker.Worker;
+import io.temporal.worker.WorkerFactory;
+import io.temporal.workflow.Workflow;
+import io.temporal.activity.Activity;
+
+// Cadence
+import com.uber.cadence.client.WorkflowClient;
+import com.uber.cadence.client.WorkflowClientOptions;
+import com.uber.cadence.client.WorkflowOptions;
+import com.uber.cadence.serviceclient.ClientOptions;
+import com.uber.cadence.serviceclient.IWorkflowService;
+import com.uber.cadence.serviceclient.WorkflowServiceTChannel;
+import com.uber.cadence.worker.Worker;
+import com.uber.cadence.worker.WorkerFactory;
+import com.uber.cadence.workflow.Workflow;
+import com.uber.cadence.activity.Activity;
+```
+
+### Client setup
+
+```java
+// Cadence
+IWorkflowService service = new WorkflowServiceTChannel(ClientOptions.defaultInstance());
+WorkflowClient client = WorkflowClient.newInstance(service,
+    WorkflowClientOptions.newBuilder().setDomain("your-domain").build());
+```
+
+### Starting a workflow
+
+```java
+// Temporal
+WorkflowOptions options = WorkflowOptions.newBuilder()
+    .setTaskQueue("my-task-queue")
+    .build();
+
+// Cadence
+WorkflowOptions options = new WorkflowOptions.Builder()
+    .setTaskList("my-task-list")
+    .build();
+```
+
+## What stays the same
+
+Workflow and activity implementation code is nearly identical between the two SDKs — the programming model, determinism constraints, signal/query patterns, child workflows, and retry policies all work the same way. Most of the migration work is in the client/worker setup and the namespace→domain and task-queue→task-list renames.
+
+## Further reading
+
+- [Cadence vs Temporal comparison](/faq/cadence-vs-temporal) — feature-by-feature comparison
+- [Go client workers](/docs/go-client/workers) — full worker setup guide
+- [Java client overview](/docs/java-client/client-overview) — Java client reference

--- a/sidebarsFAQ.js
+++ b/sidebarsFAQ.js
@@ -7,6 +7,8 @@ export default {
     // },
     { type: 'doc', id: 'best-practices' },
     { type: 'doc', id: 'cadence-vs-temporal' },
+    { type: 'doc', id: 'cadence-faq' },
+    { type: 'doc', id: 'migrate-from-temporal' },
     { type: 'doc', id: 'how-to-add-a-new-faq' },
   ],
 };


### PR DESCRIPTION
**What changed?**

- \`docs/03-concepts/01-workflows.md\`: added H1, updated description and intro paragraph to introduce durable execution terminology alongside the existing fault-oblivious framing
- \`docs/02-use-cases/index.md\`: added H1 and a brief opening that connects the use cases section to the durable execution model; expanded keywords
- \`faq/cadence-faq.mdx\`: new page covering what Cadence is, workflow vs activity, Cadence vs message queues, failure handling, long-running workflows, and a pointer to the Temporal comparison page
- \`faq/migrate-from-temporal.mdx\`: new page with Go and Java SDK package imports, concept renames (Namespace→Domain, TaskQueue→TaskList), and client/worker setup examples for teams migrating from Temporal
- \`sidebarsFAQ.js\`: added cadence-faq and migrate-from-temporal to the FAQ sidebar

**Why?**

The term "durable execution" appeared nowhere in the docs despite being the primary concept people search for when evaluating workflow engines. The workflows and use-cases pages used "fault-oblivious" framing exclusively, which is accurate but not how developers search. The two new FAQ pages fill gaps for teams actively evaluating or migrating from Temporal — common questions about Cadence basics and a practical SDK migration reference.

**How did you verify it?**

\`npm run build\` — clean build, no broken links or sidebar errors.
\`npm run start\` — verified all new and updated pages render correctly.

- Ran production preview (\`npm run preview:github-pages -- --serve\`)
- Checked dark mode and light mode on affected pages

**Potential risks**

None. All changes are additive documentation. No existing pages were removed or restructured.

**Related changes**

Companion PR #361 adds the Cadence Cost Calculator page and links to it from related concept pages.