### PR TITLE
feat: add Week 2 claim-check blog post with interactive React components

### DIFF
--- a/blog/2026-06-10-claim-check-pattern/2026-06-10-claim-check-pattern.mdx
+++ b/blog/2026-06-10-claim-check-pattern/2026-06-10-claim-check-pattern.mdx
@@ -1,0 +1,81 @@
+---
+title: "Bypass the 2 MB Limit Without Shrinking Your Workflow"
+description: "The claim-check pattern offloads large Cadence payloads to an external blob store so only a tiny reference travels through workflow history. Learn the replay-safety requirements, blob key rules, and how to run the Go and Java samples."
+keywords:
+  - cadence claim check pattern
+  - cadence payload size limit
+  - cadence dataconverter blob store
+  - cadence workflow history size
+  - cadence s3 dataconverter
+  - cadence replay safety
+  - deterministic blob keys
+date: 2026-06-10T09:00
+authors: kevinb
+tags:
+  - announcement
+  - deep-dive
+---
+
+import PayloadFlowDemo from './PayloadFlowDemo';
+import SizeChart from './SizeChart';
+import FootgunCards from './FootgunCards';
+import BlobStoreTabs from './BlobStoreTabs';
+
+The 2 MB per-payload limit in Cadence does not come with a helpful error. Your workflow does not receive a graceful degradation notice. It just fails. And if you have never hit the limit before, the stack trace is not obvious about what happened.
+
+The claim-check pattern solves this completely. Instead of compressing a large payload and hoping it fits, you offload it to an external blob store and write only a small reference into Cadence history. The limit no longer applies to your payload; only to the reference, which is always tiny.
+
+<!-- truncate -->
+
+## How it works
+
+The `DataConverter` intercepts every payload before it reaches Cadence history. With claim-check, it makes a size decision on each one:
+
+- **At or below the threshold (4 KB in the demo):** payload is stored inline in history, prefixed with `0x00`.
+- **Above the threshold:** payload is written to an external blob store. Only a small JSON reference (the blob key) is stored in history, prefixed with `0x01`.
+
+On the decode side, the worker reads the prefix byte and either uses the inline payload directly or fetches it from the blob store.
+
+<PayloadFlowDemo />
+
+## Threshold tuning
+
+The default threshold in the samples is 4 KB. In production, profile your actual payload sizes first:
+
+- **Too low:** nearly everything gets offloaded, meaning more blob store API calls and more latency per payload.
+- **Too high:** large payloads still slip into Cadence history and approach the 2 MB cap.
+
+A reasonable starting point for most teams is 64 KB–256 KB, then adjust based on observed payload distribution.
+
+<SizeChart />
+
+## Blob store options
+
+<BlobStoreTabs />
+
+## The one rule you cannot skip
+
+Blob keys must be **deterministic**.
+
+Cadence can replay a workflow from the beginning at any time (to recover from a crash, to apply a code change, or during normal task processing). When it does, `ToData` is called again with the same payload.
+
+If your key is a UUID, every replay writes a new blob and orphans the old one. After enough replays, you have a storage bill full of blobs no one can find.
+
+The fix is a single line: use SHA-256 of the serialized payload as the key. The same payload always produces the same key. The `Put` on replay is a no-op.
+
+## Common production pitfalls
+
+<FootgunCards />
+
+## What's next in this series
+
+**Week 3: Encrypt Cadence History Payloads (And Know What You Didn't Encrypt)**
+
+Key management, the `CADENCE_ENCRYPTION_KEY` environment variable, and a practical map of what AES-256-GCM encryption protects in Cadence versus what it leaves exposed. If you handle regulated data, this is the post to bookmark.
+
+## Get started
+
+- [DataConverter Guide](/docs/concepts/data-converter)
+- [Go samples](https://github.com/cadence-workflow/cadence-samples/tree/master/new_samples/data)
+- [Java samples](https://github.com/cadence-workflow/cadence-java-samples)
+- [Community and support](/community/contact-us)

--- a/blog/2026-06-10-claim-check-pattern/BlobStoreTabs/index.tsx
+++ b/blog/2026-06-10-claim-check-pattern/BlobStoreTabs/index.tsx
@@ -1,0 +1,190 @@
+import React, { useState } from 'react';
+
+type Store = {
+  id: string;
+  label: string;
+  badge: string;
+  badgeColor: string;
+  description: string;
+  goSnippet: string;
+  javaSnippet: string;
+};
+
+const STORES: Store[] = [
+  {
+    id: 'local',
+    label: 'Local FS',
+    badge: 'Dev only',
+    badgeColor: 'var(--ifm-color-emphasis-500)',
+    description:
+      'Writes blobs to a local directory. No credentials needed. Works out of the box with the sample repos. Not suitable for production: blobs are not shared across machines and are lost on pod restart.',
+    goSnippet: `store := blobstore.NewFilesystemStore("/tmp/cadence-blobs")
+dc := claimcheck.NewDataConverter(store, 4*1024)`,
+    javaSnippet: `BlobStore store = new FilesystemBlobStore("/tmp/cadence-blobs");
+DataConverter dc = new ClaimCheckDataConverter(store, 4 * 1024);`,
+  },
+  {
+    id: 's3',
+    label: 'S3 / MinIO',
+    badge: 'Production',
+    badgeColor: 'var(--ifm-color-success)',
+    description:
+      'Recommended for most Go production deployments. Uses the standard AWS SDK v2. Works with any S3-compatible API including MinIO, Ceph, and DigitalOcean Spaces. Set credentials via environment variables or IAM role; no code change needed.',
+    goSnippet: `cfg, _ := awsconfig.LoadDefaultConfig(ctx)
+s3Client := s3.NewFromConfig(cfg)
+store := blobstore.NewS3Store(s3Client, "my-cadence-blobs")
+dc := claimcheck.NewDataConverter(store, 256*1024)`,
+    javaSnippet: `S3Client s3 = S3Client.builder().region(Region.US_EAST_1).build();
+BlobStore store = new S3BlobStore(s3, "my-cadence-blobs");
+DataConverter dc = new ClaimCheckDataConverter(store, 256 * 1024);`,
+  },
+  {
+    id: 'gcs',
+    label: 'GCS',
+    badge: 'Production',
+    badgeColor: 'var(--ifm-color-success)',
+    description:
+      'Google Cloud Storage backend. Uses Application Default Credentials, so it works with Workload Identity on GKE with no key files. Swap the store implementation; everything else stays the same.',
+    goSnippet: `client, _ := storage.NewClient(ctx)
+store := blobstore.NewGCSStore(client, "my-cadence-blobs")
+dc := claimcheck.NewDataConverter(store, 256*1024)`,
+    javaSnippet: `Storage gcs = StorageOptions.getDefaultInstance().getService();
+BlobStore store = new GCSBlobStore(gcs, "my-cadence-blobs");
+DataConverter dc = new ClaimCheckDataConverter(store, 256 * 1024);`,
+  },
+  {
+    id: 'azure',
+    label: 'Azure Blob',
+    badge: 'Production',
+    badgeColor: 'var(--ifm-color-success)',
+    description:
+      'Azure Blob Storage backend. Uses DefaultAzureCredential for managed identity support. The container must exist before the DataConverter is initialised; the store will not create it automatically.',
+    goSnippet: `cred, _ := azidentity.NewDefaultAzureCredential(nil)
+client, _ := azblob.NewClient(accountURL, cred, nil)
+store := blobstore.NewAzureStore(client, "cadence-blobs")
+dc := claimcheck.NewDataConverter(store, 256*1024)`,
+    javaSnippet: `BlobServiceClient azure = new BlobServiceClientBuilder()
+    .endpoint(accountURL)
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+BlobStore store = new AzureBlobStore(azure, "cadence-blobs");
+DataConverter dc = new ClaimCheckDataConverter(store, 256 * 1024);`,
+  },
+];
+
+type Lang = 'go' | 'java';
+
+export default function BlobStoreTabs() {
+  const [activeStore, setActiveStore] = useState<string>('local');
+  const [lang, setLang] = useState<Lang>('go');
+
+  const store = STORES.find((s) => s.id === activeStore)!;
+
+  return (
+    <div style={{ margin: '2rem 0' }}>
+      {/* Store tabs */}
+      <div style={{
+        display: 'flex',
+        gap: 0,
+        borderBottom: '2px solid var(--ifm-color-emphasis-300)',
+        marginBottom: 0,
+        flexWrap: 'wrap',
+      }}>
+        {STORES.map((s) => {
+          const active = s.id === activeStore;
+          return (
+            <button
+              key={s.id}
+              onClick={() => setActiveStore(s.id)}
+              style={{
+                padding: '8px 18px',
+                border: 'none',
+                borderBottom: active
+                  ? '2px solid var(--ifm-color-primary)'
+                  : '2px solid transparent',
+                marginBottom: -2,
+                background: 'transparent',
+                cursor: 'pointer',
+                fontWeight: active ? 700 : 400,
+                fontSize: 14,
+                color: active ? 'var(--ifm-color-primary)' : 'var(--ifm-color-emphasis-700)',
+                transition: 'color 0.15s',
+              }}
+            >
+              {s.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Panel */}
+      <div style={{
+        border: '1px solid var(--ifm-color-emphasis-300)',
+        borderTop: 'none',
+        borderRadius: '0 0 8px 8px',
+        background: 'var(--ifm-background-surface-color)',
+        padding: '1.2rem',
+      }}>
+        {/* Badge + description */}
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10, marginBottom: 12 }}>
+          <span style={{
+            display: 'inline-block',
+            padding: '2px 10px',
+            borderRadius: 12,
+            fontSize: 11,
+            fontWeight: 700,
+            background: store.badgeColor,
+            color: '#fff',
+            whiteSpace: 'nowrap',
+            flexShrink: 0,
+            marginTop: 2,
+          }}>
+            {store.badge}
+          </span>
+          <p style={{ margin: 0, fontSize: 13, color: 'var(--ifm-font-color-base)', lineHeight: 1.6 }}>
+            {store.description}
+          </p>
+        </div>
+
+        {/* Language toggle */}
+        <div style={{ display: 'flex', gap: 6, marginBottom: 10 }}>
+          {(['go', 'java'] as Lang[]).map((l) => (
+            <button
+              key={l}
+              onClick={() => setLang(l)}
+              style={{
+                padding: '3px 14px',
+                borderRadius: 5,
+                border: '1px solid var(--ifm-color-emphasis-300)',
+                background: lang === l ? 'var(--ifm-color-emphasis-200)' : 'transparent',
+                color: 'var(--ifm-font-color-base)',
+                cursor: 'pointer',
+                fontWeight: lang === l ? 700 : 400,
+                fontSize: 12,
+              }}
+            >
+              {l === 'go' ? 'Go' : 'Java'}
+            </button>
+          ))}
+        </div>
+
+        {/* Code snippet */}
+        <pre style={{
+          margin: 0,
+          padding: '12px 14px',
+          borderRadius: 6,
+          background: 'var(--ifm-code-background)',
+          fontSize: 12,
+          overflowX: 'auto',
+          lineHeight: 1.6,
+        }}>
+          <code>{lang === 'go' ? store.goSnippet : store.javaSnippet}</code>
+        </pre>
+
+        <p style={{ margin: '10px 0 0', fontSize: 11, color: 'var(--ifm-color-emphasis-600)' }}>
+          All backends implement the same <code>BlobStore</code> interface, so swapping is a one-line config change.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/blog/2026-06-10-claim-check-pattern/FootgunCards/index.tsx
+++ b/blog/2026-06-10-claim-check-pattern/FootgunCards/index.tsx
@@ -1,0 +1,160 @@
+import React, { useState } from 'react';
+
+type Footgun = {
+  icon: string;
+  title: string;
+  what: string;
+  fix: string;
+  fixCode?: string;
+};
+
+const FOOTGUNS: Footgun[] = [
+  {
+    icon: '🔑',
+    title: 'UUID blob keys',
+    what: 'Every replay of a workflow calls ToData again with the same payload. A UUID key writes a fresh blob each time and orphans the previous one. After a week in production, your blob store is full of unreachable objects.',
+    fix: 'Use SHA-256 of the serialized payload as the key. The same payload always hashes to the same key, so a re-put on replay is a no-op.',
+    fixCode: `key := fmt.Sprintf("%x", sha256.Sum256(data))`,
+  },
+  {
+    icon: '⏱️',
+    title: 'Blob TTL shorter than history retention',
+    what: 'If you set a 7-day TTL on blobs but your Cadence namespace retains history for 30 days, a replay on day 10 will try to fetch a blob that no longer exists. The decode fails, the task retries forever.',
+    fix: 'Set blob TTL ≥ your longest workflow execution lifetime, not your namespace retention period. When in doubt, use no TTL and rely on explicit cleanup.',
+  },
+  {
+    icon: '🔌',
+    title: 'Blob store treated as optional',
+    what: 'The blob store is now on the critical path for every worker that processes tasks for workflows using claim-check. An outage or network blip causes decode failures and infinite task retries, not a clean workflow error.',
+    fix: 'Treat blob store availability like a database dependency. Add health checks, alerts, and circuit breakers. Document the dependency in your runbook.',
+  },
+  {
+    icon: '🔢',
+    title: 'Prefix byte schema change mid-flight',
+    what: 'The DataConverter uses a prefix byte (0x00 = inline, 0x01 = claim-check) to know how to decode each payload. If you change the meaning of those bytes in a new deployment, workers decoding old history events will misread the prefix and corrupt the payload.',
+    fix: 'Freeze the prefix schema on day one. Add new prefix values for new behaviors; never reuse or remove existing ones. Treat it like a Protobuf field number.',
+  },
+  {
+    icon: '🔐',
+    title: 'Missing blob store credentials on workers',
+    what: 'The Cadence client writes blobs during ToData (encode). Workers read them during FromData (decode). If your workers have a different IAM role or network path than your client, encodes succeed silently but every decode fails at runtime.',
+    fix: 'Verify that both your Cadence client and all worker processes have read+write access to the blob store. Test this at deploy time, not at incident time.',
+  },
+];
+
+export default function FootgunCards() {
+  const [open, setOpen] = useState<number | null>(null);
+
+  return (
+    <div style={{ margin: '2rem 0', display: 'flex', flexDirection: 'column', gap: 10 }}>
+      {FOOTGUNS.map((fg, i) => {
+        const isOpen = open === i;
+        return (
+          <div
+            key={i}
+            style={{
+              border: `1px solid ${isOpen ? 'var(--ifm-color-danger)' : 'var(--ifm-color-emphasis-300)'}`,
+              borderRadius: 8,
+              overflow: 'hidden',
+              transition: 'border-color 0.2s',
+            }}
+          >
+            {/* Header */}
+            <button
+              onClick={() => setOpen(isOpen ? null : i)}
+              style={{
+                width: '100%',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                padding: '12px 16px',
+                background: isOpen
+                  ? 'color-mix(in srgb, var(--ifm-color-danger) 8%, var(--ifm-background-surface-color))'
+                  : 'var(--ifm-background-surface-color)',
+                border: 'none',
+                cursor: 'pointer',
+                textAlign: 'left',
+                transition: 'background 0.2s',
+              }}
+            >
+              <span style={{ fontSize: 20, lineHeight: 1 }}>{fg.icon}</span>
+              <span style={{
+                flex: 1,
+                fontWeight: 600,
+                fontSize: 14,
+                color: 'var(--ifm-font-color-base)',
+              }}>
+                {fg.title}
+              </span>
+              <span style={{
+                fontSize: 18,
+                color: 'var(--ifm-color-emphasis-500)',
+                transform: isOpen ? 'rotate(90deg)' : 'rotate(0deg)',
+                transition: 'transform 0.2s',
+                lineHeight: 1,
+              }}>
+                ›
+              </span>
+            </button>
+
+            {/* Body */}
+            {isOpen && (
+              <div style={{
+                padding: '0 16px 16px',
+                background: 'var(--ifm-background-surface-color)',
+              }}>
+                <div style={{ marginBottom: 12 }}>
+                  <div style={{
+                    fontSize: 11,
+                    fontWeight: 700,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.06em',
+                    color: 'var(--ifm-color-danger)',
+                    marginBottom: 4,
+                  }}>
+                    What happens
+                  </div>
+                  <p style={{ margin: 0, fontSize: 13, color: 'var(--ifm-font-color-base)', lineHeight: 1.6 }}>
+                    {fg.what}
+                  </p>
+                </div>
+
+                <div style={{
+                  borderTop: '1px solid var(--ifm-color-emphasis-200)',
+                  paddingTop: 12,
+                }}>
+                  <div style={{
+                    fontSize: 11,
+                    fontWeight: 700,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.06em',
+                    color: 'var(--ifm-color-success)',
+                    marginBottom: 4,
+                  }}>
+                    Fix
+                  </div>
+                  <p style={{ margin: 0, fontSize: 13, color: 'var(--ifm-font-color-base)', lineHeight: 1.6 }}>
+                    {fg.fix}
+                  </p>
+                  {fg.fixCode && (
+                    <pre style={{
+                      marginTop: 10,
+                      padding: '8px 12px',
+                      borderRadius: 6,
+                      background: 'var(--ifm-code-background)',
+                      fontSize: 12,
+                      overflowX: 'auto',
+                      margin: '10px 0 0',
+                    }}>
+                      <code>{fg.fixCode}</code>
+                    </pre>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/blog/2026-06-10-claim-check-pattern/PayloadFlowDemo/index.tsx
+++ b/blog/2026-06-10-claim-check-pattern/PayloadFlowDemo/index.tsx
@@ -1,0 +1,356 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+// ─── Layout constants ──────────────────────────────────────────────────────
+const W = 700;
+const H = 200;
+const NODE_R = 38;
+const BLOB_R = 38;
+const R_LARGE = 10;
+const R_SMALL = 6;
+const SPEED = 0.008;
+const SHRINK_STEPS = 40;
+
+const NODES = [
+  { id: 'worker',  label: 'Worker',        x: 80,  y: 100 },
+  { id: 'conv',    label: 'DataConverter', x: 270, y: 100 },
+  { id: 'blob',    label: 'Blob Store',    x: 460, y: 40  },
+  { id: 'history', label: 'History',       x: 620, y: 100 },
+];
+
+const ENCODE_EDGES = [
+  { from: 'worker',  to: 'conv',    label: 'large payload' },
+  { from: 'conv',    to: 'blob',    label: 'PUT blob'       },
+  { from: 'conv',    to: 'history', label: 'tiny ref'       },
+];
+const DECODE_EDGES = [
+  { from: 'history', to: 'conv',    label: 'tiny ref'       },
+  { from: 'conv',    to: 'blob',    label: 'GET blob'       },
+  { from: 'conv',    to: 'worker',  label: 'full payload'   },
+];
+
+type Mode = 'encode' | 'decode';
+type Phase = 'legs' | 'shrink';
+
+type Particle = {
+  id: number;
+  edgeIdx: number;
+  t: number;
+  label: string;
+  r: number;           // current rendered radius
+  labelOpacity: number; // 1 normally; fades to 0 during shrink
+  large: boolean;       // whether this started as a large payload
+};
+
+let nextId = 0;
+
+function nodePos(id: string) {
+  return NODES.find((n) => n.id === id)!;
+}
+
+function edgePath(from: string, to: string): { d: string; mx: number; my: number } {
+  const f = nodePos(from);
+  const t = nodePos(to);
+  const cx = (f.x + t.x) / 2;
+  const cy = (f.y + t.y) / 2 - 30;
+  return { d: `M ${f.x} ${f.y} Q ${cx} ${cy} ${t.x} ${t.y}`, mx: cx, my: cy };
+}
+
+function bezierPoint(from: string, to: string, t: number): { x: number; y: number } {
+  const f = nodePos(from);
+  const tk = nodePos(to);
+  const cx = (f.x + tk.x) / 2;
+  const cy = (f.y + tk.y) / 2 - 30;
+  const x = (1 - t) * (1 - t) * f.x + 2 * (1 - t) * t * cx + t * t * tk.x;
+  const y = (1 - t) * (1 - t) * f.y + 2 * (1 - t) * t * cy + t * t * tk.y;
+  return { x, y };
+}
+
+export default function PayloadFlowDemo() {
+  const [mode, setMode] = useState<Mode>('encode');
+  const [particles, setParticles] = useState<Particle[]>([]);
+  const [running, setRunning] = useState(false);
+  const [step, setStep] = useState(0);
+  const [phase, setPhase] = useState<Phase>('legs');
+  const rafRef = useRef<number | null>(null);
+
+  const edges = mode === 'encode' ? ENCODE_EDGES : DECODE_EDGES;
+
+  function reset() {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    setParticles([]);
+    setStep(0);
+    setPhase('legs');
+    setRunning(false);
+  }
+
+  function play() {
+    reset();
+    setRunning(true);
+  }
+
+  // ── Shrink phase: dot shrinks and label fades at the Blob Store node ──────
+  useEffect(() => {
+    if (!running || phase !== 'shrink') return;
+
+    let progress = 0;
+
+    function shrinkTick() {
+      progress = Math.min(progress + 1 / SHRINK_STEPS, 1);
+      setParticles((prev) =>
+        prev.map((p) =>
+          p.edgeIdx === 1
+            ? {
+                ...p,
+                r: R_LARGE - (R_LARGE - R_SMALL) * progress,
+                labelOpacity: 1 - progress,
+              }
+            : p
+        )
+      );
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(shrinkTick);
+      } else {
+        // Remove the shrunken blob particle before leg 3 starts
+        setParticles((prev) => prev.filter((p) => p.edgeIdx !== 1));
+        setPhase('legs');
+        setStep(2);
+      }
+    }
+
+    rafRef.current = requestAnimationFrame(shrinkTick);
+    return () => { if (rafRef.current) cancelAnimationFrame(rafRef.current); };
+  }, [running, phase]);
+
+  // ── Legs phase: animate one edge at a time ────────────────────────────────
+  useEffect(() => {
+    if (!running || phase !== 'legs') return;
+    if (step >= edges.length) {
+      setRunning(false);
+      return;
+    }
+
+    const edge = edges[step];
+    const pid = nextId++;
+    // Large dot on: encode leg 0 (Worker→Conv) and leg 1 (Conv→Blob)
+    // Large dot on: decode leg 2 (Conv→Worker)
+    const isLarge =
+      (mode === 'encode' && step <= 1) ||
+      (mode === 'decode' && step === 2);
+
+    setParticles((prev) => [
+      ...prev,
+      { id: pid, edgeIdx: step, t: 0, label: edge.label, r: isLarge ? R_LARGE : R_SMALL, labelOpacity: 1, large: isLarge },
+    ]);
+
+    let localT = 0;
+
+    function tick() {
+      localT = Math.min(localT + SPEED, 1);
+      setParticles((prev) =>
+        prev.map((p) => (p.id === pid ? { ...p, t: localT } : p))
+      );
+      if (localT < 1) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        // After encode leg 1 arrives at Blob Store, pause for the shrink
+        if (mode === 'encode' && step === 1) {
+          setPhase('shrink');
+        } else {
+          // Remove the completed particle, then advance
+          setParticles((prev) => prev.filter((p) => p.id !== pid));
+          setStep((s) => s + 1);
+        }
+      }
+    }
+
+    rafRef.current = requestAnimationFrame(tick);
+    return () => { if (rafRef.current) cancelAnimationFrame(rafRef.current); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [running, step, phase]);
+
+  useEffect(() => { reset(); }, [mode]);
+
+  const isBlobActive =
+    phase === 'shrink' ||
+    (mode === 'encode' ? particles.some((p) => p.edgeIdx === 1 && p.t > 0.5)
+                       : particles.some((p) => p.edgeIdx === 1 && p.t < 0.5));
+
+  return (
+    <div style={{ margin: '2rem 0' }}>
+      {/* Mode toggle */}
+      <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+        {(['encode', 'decode'] as Mode[]).map((m) => (
+          <button
+            key={m}
+            onClick={() => { setMode(m); }}
+            style={{
+              padding: '5px 18px',
+              borderRadius: 6,
+              background: 'transparent',
+              color: mode === m ? 'var(--ifm-color-primary)' : 'var(--ifm-font-color-base)',
+              border: 'none',
+              borderBottom: mode === m ? '2px solid var(--ifm-color-primary)' : '2px solid transparent',
+              cursor: 'pointer',
+              fontWeight: 600,
+              fontSize: 13,
+              textTransform: 'capitalize',
+            }}
+          >
+            {m}
+          </button>
+        ))}
+        <button
+          onClick={play}
+          disabled={running}
+          style={{
+            marginLeft: 'auto',
+            padding: '5px 16px',
+            borderRadius: 6,
+            border: 'none',
+            background: running ? 'var(--ifm-color-emphasis-300)' : 'var(--ifm-color-success)',
+            color: running ? 'var(--ifm-color-emphasis-700)' : '#fff',
+            cursor: running ? 'not-allowed' : 'pointer',
+            fontWeight: 600,
+            fontSize: 13,
+          }}
+        >
+          {running ? 'Animating…' : 'Play ▶'}
+        </button>
+        <button
+          onClick={reset}
+          style={{
+            padding: '5px 12px',
+            borderRadius: 6,
+            border: '1px solid var(--ifm-color-emphasis-300)',
+            background: 'transparent',
+            color: 'var(--ifm-font-color-base)',
+            cursor: 'pointer',
+            fontSize: 13,
+          }}
+        >
+          Reset
+        </button>
+      </div>
+
+      {/* SVG diagram */}
+      <div style={{
+        border: '1px solid var(--ifm-color-emphasis-300)',
+        borderRadius: 10,
+        background: 'var(--ifm-background-surface-color)',
+        overflow: 'hidden',
+      }}>
+        <svg viewBox={`0 0 ${W} ${H}`} style={{ width: '100%', display: 'block' }}>
+          <defs>
+            <marker id="arrow" markerWidth="8" markerHeight="6" refX="6" refY="3" orient="auto">
+              <polygon points="0 0, 8 3, 0 6" fill="var(--ifm-color-emphasis-500)" />
+            </marker>
+            <marker id="arrow-active" markerWidth="8" markerHeight="6" refX="6" refY="3" orient="auto">
+              <polygon points="0 0, 8 3, 0 6" fill="var(--ifm-color-primary)" />
+            </marker>
+          </defs>
+
+          {/* Edges */}
+          {edges.map((edge, i) => {
+            const { d, mx, my } = edgePath(edge.from, edge.to);
+            const isActive = step === i && running && phase === 'legs';
+            const isDone = step > i || (phase === 'shrink' && i <= 1);
+            return (
+              <g key={`edge-${i}`}>
+                <path
+                  d={d}
+                  fill="none"
+                  stroke={isDone ? 'var(--ifm-color-primary)' : 'var(--ifm-color-emphasis-300)'}
+                  strokeWidth={isDone ? 2.5 : 1.5}
+                  strokeDasharray={isActive ? '6 4' : 'none'}
+                  markerEnd={isDone ? 'url(#arrow-active)' : 'url(#arrow)'}
+                  opacity={isActive || isDone ? 1 : 0.4}
+                />
+                <text
+                  x={mx} y={my - 6}
+                  textAnchor="middle"
+                  fontSize={10}
+                  fill={isDone ? 'var(--ifm-color-primary)' : 'var(--ifm-color-emphasis-600)'}
+                  fontWeight={isDone ? 600 : 400}
+                >
+                  {edge.label}
+                </text>
+              </g>
+            );
+          })}
+
+          {/* Blob store vertical connector */}
+          <line
+            x1={NODES[2].x} y1={NODES[2].y + BLOB_R}
+            x2={NODES[1].x} y2={NODES[1].y - NODE_R}
+            stroke="var(--ifm-color-emphasis-200)"
+            strokeWidth={1}
+            strokeDasharray="4 3"
+          />
+
+          {/* Nodes */}
+          {NODES.map((n) => {
+            const isBlob = n.id === 'blob';
+            const r = isBlob ? BLOB_R : NODE_R;
+            const active = isBlob && isBlobActive;
+            return (
+              <g key={n.id}>
+                <circle
+                  cx={n.x} cy={n.y} r={r}
+                  fill={active ? 'var(--ifm-color-warning-contrast-background, #fffbeb)' : 'var(--ifm-background-surface-color)'}
+                  stroke={active ? 'var(--ifm-color-warning)' : 'var(--ifm-color-emphasis-400)'}
+                  strokeWidth={active ? 2.5 : 1.5}
+                />
+                <text
+                  x={n.x} y={n.y + 1}
+                  textAnchor="middle"
+                  dominantBaseline="middle"
+                  fontSize={10}
+                  fontWeight={600}
+                  fill="var(--ifm-font-color-base)"
+                >
+                  {n.label.includes(' ')
+                    ? n.label.split(' ').map((word, wi) => (
+                        <tspan key={wi} x={n.x} dy={wi === 0 ? -6 : 13}>{word}</tspan>
+                      ))
+                    : n.label}
+                </text>
+              </g>
+            );
+          })}
+
+          {/* Particles */}
+          {particles.map((p) => {
+            const edge = edges[p.edgeIdx];
+            const pos = bezierPoint(edge.from, edge.to, p.t);
+            // Color flips from danger to primary halfway through the shrink
+            const isRed = p.large && p.labelOpacity > 0.5;
+            const color = isRed ? 'var(--ifm-color-danger)' : 'var(--ifm-color-primary)';
+            return (
+              <g key={p.id}>
+                <circle cx={pos.x} cy={pos.y} r={p.r} fill={color} opacity={0.9} />
+                {p.large && p.labelOpacity > 0 && (
+                  <text
+                    x={pos.x} y={pos.y - 15}
+                    textAnchor="middle"
+                    fontSize={9}
+                    fill="var(--ifm-color-danger)"
+                    fontWeight={700}
+                    opacity={p.labelOpacity}
+                  >
+                    large
+                  </text>
+                )}
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+
+      <p style={{ fontSize: 12, color: 'var(--ifm-color-emphasis-600)', marginTop: '0.6rem' }}>
+        {mode === 'encode'
+          ? 'Encode: large payload goes to the blob store; only a tiny reference enters Cadence history.'
+          : 'Decode: worker reads the reference from history, fetches the full payload from the blob store.'}
+      </p>
+    </div>
+  );
+}

--- a/blog/2026-06-10-claim-check-pattern/SizeChart/index.tsx
+++ b/blog/2026-06-10-claim-check-pattern/SizeChart/index.tsx
@@ -1,0 +1,187 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+type Row = {
+  label: string;
+  inlineKB: number;
+  claimKB: number;
+};
+
+const ROWS: Row[] = [
+  { label: 'Small signal\n(1 KB)',       inlineKB:     1, claimKB:   0.1 },
+  { label: 'Activity result\n(50 KB)',   inlineKB:    50, claimKB:   0.1 },
+  { label: 'JSON report\n(500 KB)',      inlineKB:   500, claimKB:   0.1 },
+  { label: 'Binary blob\n(1.8 MB)',      inlineKB:  1800, claimKB:   0.1 },
+  { label: 'Over the limit\n(3 MB)',     inlineKB:  3000, claimKB:   0.1 },
+];
+
+const MAX_KB = 3000;
+const BAR_MAX_W = 340; // px, max bar width
+const LIMIT_KB = 2048; // 2 MB
+const LIMIT_X = (LIMIT_KB / MAX_KB) * BAR_MAX_W;
+
+function kbLabel(kb: number): string {
+  if (kb >= 1024) return `${(kb / 1024).toFixed(1)} MB`;
+  if (kb < 1) return `${(kb * 1024).toFixed(0)} B`;
+  return `${kb} KB`;
+}
+
+function Bar({
+  kb,
+  maxKb,
+  color,
+  animated,
+}: {
+  kb: number;
+  maxKb: number;
+  color: string;
+  animated: boolean;
+}) {
+  const [width, setWidth] = useState(0);
+  const target = Math.max((kb / maxKb) * BAR_MAX_W, 3);
+
+  useEffect(() => {
+    if (!animated) { setWidth(0); return; }
+    const t = setTimeout(() => setWidth(target), 60);
+    return () => clearTimeout(t);
+  }, [animated, target]);
+
+  const overLimit = kb > LIMIT_KB;
+
+  return (
+    <div style={{ position: 'relative', height: 22, display: 'flex', alignItems: 'center' }}>
+      <div
+        style={{
+          height: 18,
+          width: animated ? width : target,
+          background: overLimit ? 'var(--ifm-color-danger)' : color,
+          borderRadius: 3,
+          transition: animated ? 'width 0.7s cubic-bezier(0.4,0,0.2,1)' : 'none',
+          flexShrink: 0,
+        }}
+      />
+      <span style={{
+        marginLeft: 8,
+        fontSize: 11,
+        color: overLimit ? 'var(--ifm-color-danger)' : 'var(--ifm-color-emphasis-700)',
+        fontWeight: overLimit ? 700 : 400,
+        whiteSpace: 'nowrap',
+      }}>
+        {kbLabel(kb)}{overLimit ? ' (exceeds limit)' : ''}
+      </span>
+    </div>
+  );
+}
+
+export default function SizeChart() {
+  const [animated, setAnimated] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Animate on first intersection
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) { setAnimated(true); observer.disconnect(); } },
+      { threshold: 0.3 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={ref} style={{ margin: '2rem 0' }}>
+      {/* Legend */}
+      <div style={{ display: 'flex', gap: 20, marginBottom: 16, flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13 }}>
+          <div style={{ width: 14, height: 14, borderRadius: 3, background: 'var(--ifm-color-emphasis-500)' }} />
+          Inline in history (no converter)
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13 }}>
+          <div style={{ width: 14, height: 14, borderRadius: 3, background: 'var(--ifm-color-primary)' }} />
+          Claim-check (reference in history)
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13 }}>
+          <div style={{ width: 14, height: 14, borderRadius: 3, background: 'var(--ifm-color-danger)' }} />
+          Exceeds 2 MB limit
+        </div>
+      </div>
+
+      {/* Chart */}
+      <div style={{
+        border: '1px solid var(--ifm-color-emphasis-300)',
+        borderRadius: 10,
+        background: 'var(--ifm-background-surface-color)',
+        padding: '1.2rem 1rem',
+        overflowX: 'auto',
+      }}>
+        {/* Header row */}
+        <div style={{ display: 'grid', gridTemplateColumns: '130px 1fr', gap: 8, marginBottom: 8 }}>
+          <div />
+          <div style={{ position: 'relative', height: 20 }}>
+            {/* Limit marker label */}
+            <div style={{
+              position: 'absolute',
+              left: LIMIT_X - 1,
+              top: 0,
+              borderLeft: '2px dashed var(--ifm-color-danger)',
+              height: '100%',
+              paddingLeft: 4,
+              fontSize: 10,
+              color: 'var(--ifm-color-danger)',
+              whiteSpace: 'nowrap',
+              fontWeight: 600,
+            }}>
+              2 MB limit
+            </div>
+          </div>
+        </div>
+
+        {ROWS.map((row) => (
+          <div
+            key={row.label}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '130px 1fr',
+              gap: 8,
+              marginBottom: 14,
+              position: 'relative',
+            }}
+          >
+            {/* Row label */}
+            <div style={{
+              fontSize: 12,
+              color: 'var(--ifm-font-color-base)',
+              fontWeight: 500,
+              lineHeight: 1.3,
+              paddingTop: 2,
+              whiteSpace: 'pre-line',
+            }}>
+              {row.label}
+            </div>
+
+            {/* Bars */}
+            <div style={{ position: 'relative' }}>
+              {/* 2 MB limit line running through bars */}
+              <div style={{
+                position: 'absolute',
+                left: LIMIT_X,
+                top: 0,
+                bottom: 0,
+                borderLeft: '2px dashed var(--ifm-color-danger)',
+                opacity: 0.35,
+              }} />
+
+              <Bar kb={row.inlineKB} maxKb={MAX_KB} color="var(--ifm-color-emphasis-500)" animated={animated} />
+              <Bar kb={row.claimKB} maxKb={MAX_KB} color="var(--ifm-color-primary)" animated={animated} />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <p style={{ fontSize: 12, color: 'var(--ifm-color-emphasis-600)', marginTop: '0.6rem' }}>
+        Claim-check stores only a ~100 B JSON reference in Cadence history regardless of payload size.
+        The actual payload lives in the blob store.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
**What changed?**

New blog post: *Bypass the 2 MB Limit Without Shrinking Your Workflow* — Week 2 of the DataConverter series (`blog/2026-06-10-claim-check-pattern/`). MDX post with four embedded React components:

| Component | Section | Purpose |
|-----------|---------|---------|
| `PayloadFlowDemo` | How it works | Animated encode/decode particle flow; large dot shrinks at Blob Store before a tiny ref travels to History |
| `SizeChart` | Threshold tuning | Scroll-triggered bar chart — inline vs claim-check payload sizes across five examples |
| `BlobStoreTabs` | Blob store options | Tabs for Local FS / S3 / GCS / Azure with Go + Java init snippets |
| `FootgunCards` | Common production pitfalls | Five expandable cards (UUID keys, TTL mismatch, outage, prefix schema, credentials) with cause + fix |

**Why?**

Continues the DataConverter series (Week 1: #352). The claim-check pattern and its production gotchas aren't covered in the concept doc. This post fills that gap with enough depth for engineers to implement it safely.

**How did you verify it?**

- [x] Ran production preview (`npm run preview:github-pages -- --serve`)
- [x] Checked dark mode and light mode on affected pages

**Potential risks**

- New MDX post with React components. No changes to existing docs, config, or sidebar
- No new internal or external links beyond existing sample repo URLs already used in the series

**Related changes**

- Week 1 post: #352
- DataConverter concept doc: `/docs/concepts/data-converter`