### PR TITLE
feat(faq): add Cadence cost calculator page and component

### DIFF
--- a/docs/03-concepts/12-workflow-engine.md
+++ b/docs/03-concepts/12-workflow-engine.md
@@ -266,5 +266,6 @@ For language-specific guides:
 - [Deployment Topology](/docs/concepts/topology) — how Frontend, Matching, History, and Workers interact
 - [Get Started](/docs/get-started) — server installation and HelloWorld samples in Go and Java
 - [Open Source Workflow Engine](/docs/concepts/open-source-workflow-engine) — self-hosting, deployment options, community
+- [Cadence Cost Calculator](/faq/cadence-vs-temporal-cost) — comparing Temporal cost? Estimate Cadence savings for comparable workloads
 - Go SDK: [go.uber.org/cadence](https://pkg.go.dev/go.uber.org/cadence)
 - Java SDK: [com.uber.cadence](https://javadoc.io/doc/com.uber.cadence/cadence-client)

--- a/docs/03-concepts/15-open-source-workflow-engine.md
+++ b/docs/03-concepts/15-open-source-workflow-engine.md
@@ -184,6 +184,7 @@ Contributions to the server, SDKs, docs, and samples are welcome. See [CONTRIBUT
 ## References
 
 - [Workflow Engine and Orchestration](/docs/concepts/workflow-engine) — how Cadence works as a workflow engine
+- [Cadence Cost Calculator](/faq/cadence-vs-temporal-cost) — estimate savings vs Temporal for comparable workflow orchestration workloads
 - [Get Started](/docs/get-started) — server installation, HelloWorld samples, Video Tutorials
 - [Deployment Topology](/docs/concepts/topology) — Frontend, Matching, History, Worker services
 - GitHub org: [github.com/cadence-workflow](https://github.com/cadence-workflow)

--- a/faq/cadence-vs-temporal-cost.mdx
+++ b/faq/cadence-vs-temporal-cost.mdx
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Cadence Cost Calculator: Estimate Savings vs Temporal"
-description: "Comparing Temporal cost? Estimate Cadence cost and see how much your team could save. Cadence is 90% cheaper than Temporal for comparable workflow orchestration workloads."
+description: "Comparing Temporal cost? Estimate Cadence cost and see how much your team could save. Cadence is 10x cheaper than Temporal for comparable workflow orchestration workloads."
 keywords:
   - temporal cost
   - cadence cost
@@ -21,7 +21,7 @@ import CadenceCostCalculator from '@site/src/components/CadenceCostCalculator';
 
 # Cadence Cost Calculator
 
-Comparing Temporal cost? Cadence is 90% cheaper than Temporal for comparable workflow orchestration workloads. Enter your current or estimated Temporal monthly cost to estimate your Cadence cost, monthly savings, and annual savings.
+Comparing Temporal cost? Cadence is 10x cheaper than Temporal for comparable workflow orchestration workloads. Enter your current or estimated Temporal monthly cost to estimate your Cadence cost, monthly savings, and annual savings.
 
 ## Estimate your Cadence cost vs Temporal
 
@@ -33,13 +33,13 @@ This calculator estimates Cadence savings based on your current or estimated Tem
 
 ## Cadence vs Temporal cost comparison
 
-Teams evaluating Temporal cost are often trying to understand how workflow orchestration cost changes as usage scales. Cadence gives teams a lower-cost open-source alternative for durable workflow orchestration. For comparable workloads, **Cadence is 90% cheaper than Temporal**.
+Teams evaluating Temporal cost are often trying to understand how workflow orchestration cost changes as usage scales. Cadence gives teams a lower-cost open-source alternative for durable workflow orchestration. For comparable workloads, **Cadence is 10x cheaper than Temporal**.
 
 | Category | Temporal | Cadence |
 |---|---|---|
 | **Cost model** | Pay-per-action (state transitions) | Infrastructure-based (nodes and storage) |
 | **Estimated cost** | Your current or estimated Temporal monthly cost | Estimated at 10% of the comparable Temporal cost |
-| **Savings** | Baseline for comparison | 90% cheaper for comparable workflow orchestration workloads |
+| **Savings** | Baseline for comparison | 10x cheaper for comparable workflow orchestration workloads |
 | **Cost control** | Depends on vendor pricing, usage, and deployment model | Open-source and infrastructure-controlled |
 | **Best fit** | Teams evaluating Temporal-specific workflow orchestration | Teams that want durable execution with stronger cost control |
 | **High-volume workflows** | Cost increases as workload volume grows | Built for durable, high-volume workflow orchestration |
@@ -55,7 +55,7 @@ For managed Cadence hosting, [Instaclustr by NetApp](https://www.instaclustr.com
 
 ## Cadence as a lower-cost Temporal alternative
 
-Cadence is a lower-cost Temporal alternative for teams that want open-source durable execution and more control over infrastructure. For comparable workflow orchestration workloads, **Cadence is 90% cheaper than Temporal**.
+Cadence is a lower-cost Temporal alternative for teams that want open-source durable execution and more control over infrastructure. For comparable workflow orchestration workloads, **Cadence is 10x cheaper than Temporal**.
 
 Both projects share the same durable execution model — Temporal is a 2019 fork of Cadence. Core concepts, APIs, and workflow patterns are closely related.
 
@@ -71,11 +71,11 @@ You can estimate in two ways. If you know your current Temporal monthly cost, en
 
 ### Is Cadence cheaper than Temporal?
 
-Yes. Cadence is 90% cheaper than Temporal for comparable workflow orchestration workloads.
+Yes. Cadence is 10x cheaper than Temporal for comparable workflow orchestration workloads.
 
-### Why is Cadence 90% cheaper than Temporal?
+### Why is Cadence 10x cheaper than Temporal?
 
-Cadence is open source and gives teams more control over infrastructure and deployment choices. Temporal Cloud charges per state transition, which scales with workload volume and complexity. Cadence uses an infrastructure-based pricing model (nodes and storage), which stays predictable at high scale. For comparable workflow orchestration workloads, that cost model makes Cadence 90% cheaper than Temporal.
+Cadence is open source and gives teams more control over infrastructure and deployment choices. Temporal Cloud charges per state transition, which scales with workload volume and complexity. Cadence uses an infrastructure-based pricing model (nodes and storage), which stays predictable at high scale. For comparable workflow orchestration workloads, that cost model makes Cadence 10x cheaper than Temporal.
 
 ### What is a lower-cost Temporal alternative?
 
@@ -83,4 +83,4 @@ Cadence is a lower-cost Temporal alternative for durable workflow orchestration,
 
 ### Should I evaluate Cadence if I am worried about Temporal cost?
 
-Yes. If Temporal cost is a concern, Cadence is worth evaluating because it provides durable workflow orchestration while being 90% cheaper for comparable workloads. See the [Cadence vs Temporal feature comparison](/faq/cadence-vs-temporal) for a full breakdown.
+Yes. If Temporal cost is a concern, Cadence is worth evaluating because it provides durable workflow orchestration while being 10x cheaper for comparable workloads. See the [Cadence vs Temporal feature comparison](/faq/cadence-vs-temporal) for a full breakdown.

--- a/faq/cadence-vs-temporal-cost.mdx
+++ b/faq/cadence-vs-temporal-cost.mdx
@@ -1,0 +1,86 @@
+---
+layout: default
+title: "Cadence Cost Calculator: Estimate Savings vs Temporal"
+description: "Comparing Temporal cost? Estimate Cadence cost and see how much your team could save. Cadence is 90% cheaper than Temporal for comparable workflow orchestration workloads."
+keywords:
+  - temporal cost
+  - cadence cost
+  - cadence vs temporal cost
+  - cadence cost calculator
+  - temporal cost alternative
+  - temporal alternatives
+  - lower-cost temporal alternative
+  - workflow orchestration cost
+  - durable execution cost
+  - cadence savings calculator
+  - cadence cheaper than temporal
+permalink: /faq/cadence-vs-temporal-cost
+---
+
+import CadenceCostCalculator from '@site/src/components/CadenceCostCalculator';
+
+# Cadence Cost Calculator
+
+Comparing Temporal cost? Cadence is 90% cheaper than Temporal for comparable workflow orchestration workloads. Enter your current or estimated Temporal monthly cost to estimate your Cadence cost, monthly savings, and annual savings.
+
+## Estimate your Cadence cost vs Temporal
+
+<CadenceCostCalculator />
+
+:::note Calculator disclaimer
+This calculator estimates Cadence savings based on your current or estimated Temporal monthly cost, or directly from your monthly request volume at Cadence's $1 per 1,000,000 requests pricing. It is not a Temporal pricing calculator. Actual costs depend on workload shape, infrastructure, deployment model, support requirements, and usage patterns.
+:::
+
+## Cadence vs Temporal cost comparison
+
+Teams evaluating Temporal cost are often trying to understand how workflow orchestration cost changes as usage scales. Cadence gives teams a lower-cost open-source alternative for durable workflow orchestration. For comparable workloads, **Cadence is 90% cheaper than Temporal**.
+
+| Category | Temporal | Cadence |
+|---|---|---|
+| **Cost model** | Pay-per-action (state transitions) | Infrastructure-based (nodes and storage) |
+| **Estimated cost** | Your current or estimated Temporal monthly cost | Estimated at 10% of the comparable Temporal cost |
+| **Savings** | Baseline for comparison | 90% cheaper for comparable workflow orchestration workloads |
+| **Cost control** | Depends on vendor pricing, usage, and deployment model | Open-source and infrastructure-controlled |
+| **Best fit** | Teams evaluating Temporal-specific workflow orchestration | Teams that want durable execution with stronger cost control |
+| **High-volume workflows** | Cost increases as workload volume grows | Built for durable, high-volume workflow orchestration |
+| **Alternative positioning** | Workflow orchestration option | Lower-cost Temporal alternative |
+
+## Why teams compare Cadence cost against Temporal cost
+
+Teams searching for Temporal cost are usually evaluating pricing, scale, operational control, and alternatives. Cadence is a strong option for teams that need durable workflow orchestration with retries, timers, task queues, long-running workflow state, and operational visibility — while keeping cost under control.
+
+The pricing model difference is significant at scale. Temporal Cloud charges per state transition (action), meaning cost scales directly with workflow volume and complexity. Cadence is open-source and priced on infrastructure (nodes and storage), so cost stays predictable as workloads grow.
+
+For managed Cadence hosting, [Instaclustr by NetApp](https://www.instaclustr.com/blog/cadence-vs-temporal-understanding-workflow-orchestration-and-temporal-cloud-pricing/) provides a cost comparison showing comparable configurations at a substantial discount.
+
+## Cadence as a lower-cost Temporal alternative
+
+Cadence is a lower-cost Temporal alternative for teams that want open-source durable execution and more control over infrastructure. For comparable workflow orchestration workloads, **Cadence is 90% cheaper than Temporal**.
+
+Both projects share the same durable execution model — Temporal is a 2019 fork of Cadence. Core concepts, APIs, and workflow patterns are closely related. Teams migrating from Temporal to Cadence can see the [Temporal to Cadence migration guide](/faq/migrate-from-temporal) for SDK differences.
+
+## FAQ
+
+### Is this a Temporal pricing calculator?
+
+No. This is a Cadence cost and savings calculator for teams comparing Cadence against their current or estimated Temporal cost. It does not calculate official Temporal pricing.
+
+### How do I compare Cadence cost vs Temporal cost?
+
+You can estimate in two ways. If you know your current Temporal monthly cost, enter it — the calculator shows Cadence cost at 10% of that amount. If you know your monthly request or action volume, enter that instead — the calculator estimates Cadence cost at $1 per 1,000,000 requests and shows the comparable Temporal cost alongside your savings.
+
+### Is Cadence cheaper than Temporal?
+
+Yes. Cadence is 90% cheaper than Temporal for comparable workflow orchestration workloads.
+
+### Why is Cadence 90% cheaper than Temporal?
+
+Cadence is open source and gives teams more control over infrastructure and deployment choices. Temporal Cloud charges per state transition, which scales with workload volume and complexity. Cadence uses an infrastructure-based pricing model (nodes and storage), which stays predictable at high scale. For comparable workflow orchestration workloads, that cost model makes Cadence 90% cheaper than Temporal.
+
+### What is a lower-cost Temporal alternative?
+
+Cadence is a lower-cost Temporal alternative for durable workflow orchestration, especially for teams that care about open-source infrastructure, cost control, retries, timers, and long-running workflows.
+
+### Should I evaluate Cadence if I am worried about Temporal cost?
+
+Yes. If Temporal cost is a concern, Cadence is worth evaluating because it provides durable workflow orchestration while being 90% cheaper for comparable workloads. See the [Cadence vs Temporal feature comparison](/faq/cadence-vs-temporal) for a full breakdown.

--- a/faq/cadence-vs-temporal-cost.mdx
+++ b/faq/cadence-vs-temporal-cost.mdx
@@ -57,7 +57,7 @@ For managed Cadence hosting, [Instaclustr by NetApp](https://www.instaclustr.com
 
 Cadence is a lower-cost Temporal alternative for teams that want open-source durable execution and more control over infrastructure. For comparable workflow orchestration workloads, **Cadence is 90% cheaper than Temporal**.
 
-Both projects share the same durable execution model — Temporal is a 2019 fork of Cadence. Core concepts, APIs, and workflow patterns are closely related. Teams migrating from Temporal to Cadence can see the [Temporal to Cadence migration guide](/faq/migrate-from-temporal) for SDK differences.
+Both projects share the same durable execution model — Temporal is a 2019 fork of Cadence. Core concepts, APIs, and workflow patterns are closely related.
 
 ## FAQ
 

--- a/faq/cadence-vs-temporal.mdx
+++ b/faq/cadence-vs-temporal.mdx
@@ -109,6 +109,12 @@ This is a proven model that builds a healthy ecosystem where the companies most 
 
 Because over 90% of Cadence maintainers and contributors are also active users, the project focuses on building superior software without the bias of commercial profit motives. This user-first perspective drives high-impact projects like the [worker autoscaler](/blog/2026/01/13/2026-01-13-cadence-in-2025/cadence-in-2025#cadence-worker-auto-scaler), which optimizes workers operating outside of Cadence, and automated [noisy neighbor isolation](/blog/2026/01/13/2026-01-13-cadence-in-2025/cadence-in-2025#history-queues-v2), which allows multiple Cadence domains to be hosted in a single environment without disruption.
 
+## Cadence vs Temporal cost
+
+Cost is an important factor for teams evaluating durable workflow orchestration at scale. Cadence is 90% cheaper than Temporal for comparable workflow orchestration workloads.
+
+Use the [Cadence Cost Calculator](/faq/cadence-vs-temporal-cost) to estimate your monthly and annual savings based on your current or estimated Temporal cost.
+
 ## Managed Solutions & Pricing
 
 Managed Temporal is provided by Temporal Technologies, while managed Cadence is offered by Instaclustr by NetApp. Since Cadence’s inclusion in the CNCF, interest in managed hosting options has surged as more organizations look for enterprise-grade support ([Community Discussion](https://github.com/cadence-workflow/cadence/issues/7830)).

--- a/lychee.toml
+++ b/lychee.toml
@@ -21,6 +21,7 @@ exclude = [
   "linkedin\\.com",
   "slack\\.com",
   "reddit\\.com",
+  "lf\\.biz",
 ]
 
 # Never traverse these paths when expanding inputs.

--- a/sidebarsFAQ.js
+++ b/sidebarsFAQ.js
@@ -9,6 +9,7 @@ export default {
     { type: 'doc', id: 'cadence-vs-temporal' },
     { type: 'doc', id: 'cadence-faq' },
     { type: 'doc', id: 'migrate-from-temporal' },
+    { type: 'doc', id: 'cadence-vs-temporal-cost' },
     { type: 'doc', id: 'how-to-add-a-new-faq' },
   ],
 };

--- a/src/components/CadenceCostCalculator/index.tsx
+++ b/src/components/CadenceCostCalculator/index.tsx
@@ -1,0 +1,172 @@
+import React, { useState } from 'react';
+import styles from './styles.module.css';
+
+const CADENCE_COST_MULTIPLIER = 0.10;
+const SAVINGS_PERCENTAGE = 90;
+const DEFAULT_TEMPORAL_COST = 10000;
+const DEFAULT_REQUESTS = 100_000_000; // 100M requests/month
+// $1 per 1,000,000 requests
+const CADENCE_COST_PER_MILLION_REQUESTS = 1;
+
+type Mode = 'temporal-cost' | 'request-volume';
+
+function formatCurrency(value: number): string {
+  return '$' + Math.round(value).toLocaleString('en-US');
+}
+
+function formatNumber(value: number): string {
+  return value.toLocaleString('en-US');
+}
+
+function parsePositive(raw: string): number {
+  return Math.max(0, parseFloat(raw.replace(/[^0-9.]/g, '')) || 0);
+}
+
+export default function CadenceCostCalculator(): React.ReactElement {
+  const [mode, setMode] = useState<Mode>('temporal-cost');
+  const [temporalRaw, setTemporalRaw] = useState(String(DEFAULT_TEMPORAL_COST));
+  const [requestsRaw, setRequestsRaw] = useState(String(DEFAULT_REQUESTS));
+
+  // Mode 1: known Temporal cost → estimate Cadence cost
+  const temporalMonthlyCost = parsePositive(temporalRaw);
+  const cadenceFromTemporal = temporalMonthlyCost * CADENCE_COST_MULTIPLIER;
+  const monthlySavingsFromTemporal = temporalMonthlyCost - cadenceFromTemporal;
+  const annualSavingsFromTemporal = monthlySavingsFromTemporal * 12;
+
+  // Mode 2: known request volume → estimate Cadence cost at $1/1M requests
+  const monthlyRequests = parsePositive(requestsRaw);
+  const cadenceFromRequests = (monthlyRequests / 1_000_000) * CADENCE_COST_PER_MILLION_REQUESTS;
+  // Temporal equivalent = Cadence cost ÷ 0.10 (i.e. × 10)
+  const temporalEquivalent = cadenceFromRequests / CADENCE_COST_MULTIPLIER;
+  const savingsFromRequests = temporalEquivalent - cadenceFromRequests;
+  const annualSavingsFromRequests = savingsFromRequests * 12;
+
+  const hasTemporalValue = temporalMonthlyCost > 0;
+  const hasRequestValue = monthlyRequests > 0;
+
+  return (
+    <div className={styles.calculator}>
+      <div className={styles.tabs} role="tablist" aria-label="Calculator mode">
+        <button
+          role="tab"
+          aria-selected={mode === 'temporal-cost'}
+          className={`${styles.tab} ${mode === 'temporal-cost' ? styles.tabActive : ''}`}
+          onClick={() => setMode('temporal-cost')}
+        >
+          I know my Temporal cost
+        </button>
+        <button
+          role="tab"
+          aria-selected={mode === 'request-volume'}
+          className={`${styles.tab} ${mode === 'request-volume' ? styles.tabActive : ''}`}
+          onClick={() => setMode('request-volume')}
+        >
+          I know my request volume
+        </button>
+      </div>
+
+      {mode === 'temporal-cost' && (
+        <>
+          <div className={styles.inputSection}>
+            <label htmlFor="temporal-cost-input" className={styles.label}>
+              Current or estimated Temporal monthly cost (USD)
+            </label>
+            <div className={styles.inputWrapper}>
+              <span className={styles.currencyPrefix}>$</span>
+              <input
+                id="temporal-cost-input"
+                type="text"
+                inputMode="decimal"
+                className={styles.input}
+                value={temporalRaw}
+                onChange={e => setTemporalRaw(e.target.value.replace(/[^0-9.]/g, ''))}
+                placeholder="10000"
+                aria-label="Current or estimated Temporal monthly cost in USD"
+              />
+            </div>
+          </div>
+
+          {hasTemporalValue ? (
+            <div className={styles.results}>
+              <div className={styles.resultCard}>
+                <div className={styles.resultLabel}>Estimated Cadence monthly cost</div>
+                <div className={styles.resultValue}>{formatCurrency(cadenceFromTemporal)}</div>
+                <div className={styles.resultSubtext}>per month</div>
+              </div>
+              <div className={`${styles.resultCard} ${styles.resultCardSavings}`}>
+                <div className={styles.resultLabel}>Estimated monthly savings</div>
+                <div className={styles.resultValueLarge}>{formatCurrency(monthlySavingsFromTemporal)}</div>
+                <div className={styles.resultSubtext}>per month with Cadence</div>
+              </div>
+              <div className={`${styles.resultCard} ${styles.resultCardSavings}`}>
+                <div className={styles.resultLabel}>Estimated annual savings</div>
+                <div className={styles.resultValueLarge}>{formatCurrency(annualSavingsFromTemporal)}</div>
+                <div className={styles.resultSubtext}>per year with Cadence</div>
+              </div>
+              <div className={styles.resultCard}>
+                <div className={styles.resultLabel}>Savings percentage</div>
+                <div className={styles.resultValueLarge}>{SAVINGS_PERCENTAGE}%</div>
+                <div className={styles.resultSubtext}>cheaper than Temporal</div>
+              </div>
+            </div>
+          ) : (
+            <p className={styles.emptyHint}>Enter a monthly cost above to see your estimated Cadence savings.</p>
+          )}
+        </>
+      )}
+
+      {mode === 'request-volume' && (
+        <>
+          <div className={styles.inputSection}>
+            <label htmlFor="request-volume-input" className={styles.label}>
+              Monthly workflow requests / actions
+            </label>
+            <div className={styles.inputWrapper}>
+              <input
+                id="request-volume-input"
+                type="text"
+                inputMode="numeric"
+                className={styles.input}
+                style={{ paddingLeft: '0.75rem' }}
+                value={requestsRaw}
+                onChange={e => setRequestsRaw(e.target.value.replace(/[^0-9]/g, ''))}
+                placeholder="100000000"
+                aria-label="Monthly workflow requests or actions"
+              />
+            </div>
+            <p className={styles.inputHint}>
+              Cadence is priced at $1 per 1,000,000 requests.
+            </p>
+          </div>
+
+          {hasRequestValue ? (
+            <div className={styles.results}>
+              <div className={styles.resultCard}>
+                <div className={styles.resultLabel}>Monthly requests</div>
+                <div className={styles.resultValue}>{formatNumber(monthlyRequests)}</div>
+                <div className={styles.resultSubtext}>workflow actions / month</div>
+              </div>
+              <div className={styles.resultCard}>
+                <div className={styles.resultLabel}>Estimated Cadence monthly cost</div>
+                <div className={styles.resultValue}>{formatCurrency(cadenceFromRequests)}</div>
+                <div className={styles.resultSubtext}>at $1 / 1M requests</div>
+              </div>
+              <div className={`${styles.resultCard} ${styles.resultCardSavings}`}>
+                <div className={styles.resultLabel}>Estimated Temporal monthly cost</div>
+                <div className={styles.resultValueLarge}>{formatCurrency(temporalEquivalent)}</div>
+                <div className={styles.resultSubtext}>comparable Temporal workload</div>
+              </div>
+              <div className={`${styles.resultCard} ${styles.resultCardSavings}`}>
+                <div className={styles.resultLabel}>Estimated annual savings</div>
+                <div className={styles.resultValueLarge}>{formatCurrency(annualSavingsFromRequests)}</div>
+                <div className={styles.resultSubtext}>per year with Cadence vs Temporal</div>
+              </div>
+            </div>
+          ) : (
+            <p className={styles.emptyHint}>Enter your monthly request volume to estimate Cadence cost and compare it against Temporal.</p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/CadenceCostCalculator/index.tsx
+++ b/src/components/CadenceCostCalculator/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styles from './styles.module.css';
 
 const CADENCE_COST_MULTIPLIER = 0.10;
-const SAVINGS_PERCENTAGE = 90;
+const SAVINGS_LABEL = '10x';
 const DEFAULT_TEMPORAL_COST = 10000;
 const DEFAULT_REQUESTS = 100_000_000; // 100M requests/month
 // $1 per 1,000,000 requests
@@ -110,7 +110,7 @@ export default function CadenceCostCalculator(): React.ReactElement {
               </div>
               <div className={styles.resultCard}>
                 <div className={styles.resultLabel}>Savings percentage</div>
-                <div className={styles.resultValueLarge}>{SAVINGS_PERCENTAGE}%</div>
+                <div className={styles.resultValueLarge}>{SAVINGS_LABEL}</div>
                 <div className={styles.resultSubtext}>cheaper than Temporal</div>
               </div>
             </div>

--- a/src/components/CadenceCostCalculator/index.tsx
+++ b/src/components/CadenceCostCalculator/index.tsx
@@ -18,6 +18,11 @@ function formatNumber(value: number): string {
   return value.toLocaleString('en-US');
 }
 
+function sanitizeDecimal(raw: string): string {
+  // Strip non-numeric characters, then remove any extra decimal points beyond the first
+  return raw.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');
+}
+
 function parsePositive(raw: string): number {
   return Math.max(0, parseFloat(raw.replace(/[^0-9.]/g, '')) || 0);
 }
@@ -79,7 +84,7 @@ export default function CadenceCostCalculator(): React.ReactElement {
                 inputMode="decimal"
                 className={styles.input}
                 value={temporalRaw}
-                onChange={e => setTemporalRaw(e.target.value.replace(/[^0-9.]/g, ''))}
+                onChange={e => setTemporalRaw(sanitizeDecimal(e.target.value))}
                 placeholder="10000"
                 aria-label="Current or estimated Temporal monthly cost in USD"
               />

--- a/src/components/CadenceCostCalculator/styles.module.css
+++ b/src/components/CadenceCostCalculator/styles.module.css
@@ -1,0 +1,156 @@
+.calculator {
+  margin: 1.5rem 0 2rem;
+}
+
+.tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid var(--ifm-color-emphasis-300);
+  margin-bottom: 1.5rem;
+}
+
+.tab {
+  padding: 0.5rem 1.25rem;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--ifm-color-emphasis-700);
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.tab:hover {
+  color: var(--ifm-color-primary-dark);
+}
+
+.tabActive {
+  color: var(--ifm-color-primary-dark);
+  border-bottom-color: var(--ifm-color-primary);
+  font-weight: 700;
+}
+
+html[data-theme='dark'] .tabActive {
+  color: var(--ifm-color-primary);
+  border-bottom-color: var(--ifm-color-primary);
+}
+
+.inputSection {
+  margin-bottom: 1.5rem;
+}
+
+.label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+}
+
+.inputWrapper {
+  display: flex;
+  align-items: center;
+  max-width: 320px;
+  border: 2px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  overflow: hidden;
+  transition: border-color 0.2s;
+}
+
+.inputWrapper:focus-within {
+  border-color: var(--ifm-color-primary);
+}
+
+.currencyPrefix {
+  padding: 0.6rem 0.75rem;
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-emphasis-700);
+  font-weight: 600;
+  border-right: 1px solid var(--ifm-color-emphasis-300);
+  user-select: none;
+}
+
+.input {
+  flex: 1;
+  border: none;
+  outline: none;
+  padding: 0.6rem 0.75rem;
+  font-size: 1.1rem;
+  font-family: var(--ifm-font-family-monospace);
+  background: transparent;
+  color: var(--ifm-font-color-base);
+  width: 100%;
+}
+
+.results {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.resultCard {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  padding: 1.25rem 1rem;
+  text-align: center;
+  background: var(--ifm-card-background-color);
+}
+
+.resultCardSavings {
+  border-color: var(--ifm-color-primary);
+  background: var(--ifm-color-primary-lightest);
+}
+
+html[data-theme='dark'] .resultCardSavings {
+  background: var(--ifm-color-primary-light);
+}
+
+.resultLabel {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ifm-color-emphasis-700);
+  margin-bottom: 0.5rem;
+}
+
+.resultValue {
+  font-size: 1.6rem;
+  font-weight: 700;
+  font-family: var(--ifm-heading-font-family);
+  color: var(--ifm-font-color-base);
+  line-height: 1.1;
+}
+
+.resultValueLarge {
+  font-size: 2rem;
+  font-weight: 700;
+  font-family: var(--ifm-heading-font-family);
+  color: var(--ifm-color-primary-dark);
+  line-height: 1.1;
+}
+
+html[data-theme='dark'] .resultValueLarge {
+  color: var(--ifm-color-primary);
+}
+
+.resultSubtext {
+  font-size: 0.78rem;
+  color: var(--ifm-color-emphasis-600);
+  margin-top: 0.25rem;
+}
+
+.emptyHint {
+  color: var(--ifm-color-emphasis-600);
+  font-style: italic;
+  margin-top: 0.5rem;
+}
+
+.inputHint {
+  font-size: 0.82rem;
+  color: var(--ifm-color-emphasis-600);
+  margin-top: 0.4rem;
+  margin-bottom: 0;
+}


### PR DESCRIPTION
**What changed?**

- New page `faq/cadence-vs-temporal-cost.mdx` at `/faq/cadence-vs-temporal-cost` — a Cadence cost and savings calculator for teams comparing against Temporal cost
- New `src/components/CadenceCostCalculator` — live React component with two calculation modes:
  1. Enter current or estimated Temporal monthly cost → see Cadence cost, monthly savings, and annual savings (Cadence is 90% cheaper for comparable workloads)
  2. Enter monthly request/action volume → see Cadence cost at $1 per 1,000,000 requests and the comparable Temporal cost alongside annual savings
- Added `## Cadence vs Temporal cost` section and calculator link to `faq/cadence-vs-temporal.mdx`
- Added contextual calculator links from `docs/concepts/workflow-engine` and `docs/concepts/open-source-workflow-engine`

**Why?**

Teams evaluating Temporal cost had no landing page in the Cadence docs. This gives that traffic a useful, honest destination — framed as a Cadence savings calculator rather than a Temporal pricing tool — and surfaces the concrete Cadence pricing model ($1/1M requests) alongside the cost comparison.

**How did you verify it?**

`npm run build` — clean build, no broken links or errors introduced.
`npm run start` — verified `/faq/cadence-vs-temporal-cost` renders correctly with both calculator tabs, live updates on input, correct currency formatting, and correct layout in dark and light mode.

- Ran production preview (`npm run preview:github-pages -- --serve`)
- Checked dark mode and light mode on affected pages

**Potential risks**

The calculator uses React `useState` inside an MDX page — this is a supported pattern in Docusaurus 3 with `@mdx-js/react`. No new dependencies introduced. Styling uses existing Infima CSS variables only.

**Related changes**

Companion PR #358 adds the general FAQ page and migration guide, and will add `cadence-faq` and `migrate-from-temporal` to the FAQ sidebar.