### PR TITLE
feat(community): add meetup page and community CTA widget

### DIFF
--- a/community/meetup.mdx
+++ b/community/meetup.mdx
@@ -1,0 +1,53 @@
+---
+layout: default
+title: Community Meetups
+description: Join the Cadence community meetup — a recurring gathering for Cadence users and contributors to share demos, ask questions, and connect with maintainers.
+keywords:
+  - cadence meetup
+  - cadence community meetup
+  - cadence office hours
+  - cadence community events
+  - cadence workflow meetup
+  - cadence contributors meetup
+  - cadence community call
+permalink: /community/meetup
+---
+
+# Community Meetups
+
+The Cadence community meetup is a recurring gathering for users, contributors, and maintainers. Each session includes demos, open Q&A, and updates from the core team.
+
+Whether you are evaluating Cadence, running it in production, or contributing to the project — the meetup is the fastest way to get answers, see what others are building, and connect directly with maintainers.
+
+## Upcoming meetup
+
+Details for the next session will be posted here. To get notified:
+
+- Join the [**#cadence-users** channel on CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) — meetup announcements are posted there first
+- Watch the [cadence-workflow GitHub org](https://github.com/cadence-workflow) for event announcements
+
+## What to expect
+
+- **Demos** — community members and maintainers share new features, integrations, and real-world use cases
+- **Open Q&A** — bring your questions about Cadence architecture, operations, SDKs, or migration
+- **Maintainer updates** — what the core team is working on and what is coming next
+- **New contributor onboarding** — not sure how to start contributing? The meetup is a good first step
+
+## Past sessions
+
+Past meetup recordings are published on the [Cadence YouTube channel](https://www.youtube.com/@cadenceworkflow). A few recent highlights:
+
+- [Cadence in 2025 — Year in Review](https://www.youtube.com/watch?v=UmCFfEpAqNg)
+- [Cadence at Uber — Scale Overview](https://www.youtube.com/watch?v=-qj_Lb_basY)
+
+## Get involved
+
+| Channel | Link |
+|---|---|
+| CNCF Slack `#cadence-users` | [Join](https://communityinviter.com/apps/cloud-native/cncf) |
+| Discord | [discord.gg/ynvjm2Et5](https://discord.gg/ynvjm2Et5) |
+| GitHub Discussions | [cadence-workflow/cadence/discussions](https://github.com/cadence-workflow/cadence/discussions) |
+| Stack Overflow | [`cadence-workflow` tag](https://stackoverflow.com/questions/tagged/cadence-workflow) |
+| Reddit | [r/cadenceworkflow](https://www.reddit.com/r/cadenceworkflow/) |
+
+Want to present at a future meetup or propose a topic? Reach out in the `#cadence-users` Slack channel or open a [GitHub Discussion](https://github.com/cadence-workflow/cadence/discussions).

--- a/lychee.toml
+++ b/lychee.toml
@@ -20,6 +20,7 @@ exclude = [
   "^http(s)?://0\\.0\\.0\\.0",
   "linkedin\\.com",
   "slack\\.com",
+  "reddit\\.com",
 ]
 
 # Never traverse these paths when expanding inputs.

--- a/sidebarsCommunity.js
+++ b/sidebarsCommunity.js
@@ -6,6 +6,7 @@ export default {
     //   dirName: '.',
     // },
     { type: 'doc', id: 'contact-us' },
+    { type: 'doc', id: 'meetup' },
     {
       type: 'category',
       label: 'How to Contribute',

--- a/src/theme/CommunityWidget.jsx
+++ b/src/theme/CommunityWidget.jsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import { Icon } from '@iconify/react';
+import styles from './CommunityWidget.module.css';
+
+const ACTIONS = [
+  {
+    id: 'meetup',
+    label: 'Join the community meetup',
+    href: '/community/meetup',
+    icon: 'mdi:calendar-star',
+  },
+  {
+    id: 'slack',
+    label: 'Join us on Slack (CNCF)',
+    href: 'https://communityinviter.com/apps/cloud-native/cncf',
+    icon: 'mdi:slack',
+    external: true,
+  },
+  {
+    id: 'discord',
+    label: 'Join us on Discord',
+    href: 'https://discord.gg/ynvjm2Et5',
+    icon: 'mdi:discord',
+    external: true,
+  },
+  {
+    id: 'github',
+    label: 'Discuss on GitHub',
+    href: 'https://github.com/cadence-workflow/cadence/discussions',
+    icon: 'mdi:github',
+    external: true,
+  },
+  {
+    id: 'contact',
+    label: 'Contact the team',
+    href: '/community/contact-us',
+    icon: 'mdi:email-outline',
+  },
+];
+
+export default function CommunityWidget() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className={styles.widget} aria-label="Community actions">
+      {open && (
+        <div className={styles.panel} role="dialog" aria-label="Community actions menu">
+          <div className={styles.panelHeader}>
+            <span className={styles.panelTitle}>Join the Cadence community</span>
+            <button
+              className={styles.closeButton}
+              onClick={() => setOpen(false)}
+              aria-label="Close community menu"
+            >
+              <Icon icon="mdi:close" width={16} />
+            </button>
+          </div>
+          <ul className={styles.actionList}>
+            {ACTIONS.map((action) => (
+              <li key={action.id}>
+                <a
+                  href={action.href}
+                  className={styles.actionItem}
+                  target={action.external ? '_blank' : undefined}
+                  rel={action.external ? 'noopener noreferrer' : undefined}
+                  onClick={() => setOpen(false)}
+                >
+                  <Icon icon={action.icon} className={styles.actionIcon} width={20} />
+                  <span>{action.label}</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <button
+        className={`${styles.fab} ${open ? styles.fabOpen : ''}`}
+        onClick={() => setOpen((v) => !v)}
+        aria-label={open ? 'Close community menu' : 'Open community actions'}
+        aria-expanded={open}
+      >
+        <Icon icon={open ? 'mdi:close' : 'mdi:account-group'} width={26} />
+      </button>
+    </div>
+  );
+}

--- a/src/theme/CommunityWidget.jsx
+++ b/src/theme/CommunityWidget.jsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Icon } from '@iconify/react';
+import Link from '@docusaurus/Link';
 import styles from './CommunityWidget.module.css';
 
 const ACTIONS = [
@@ -40,11 +41,45 @@ const ACTIONS = [
 
 export default function CommunityWidget() {
   const [open, setOpen] = useState(false);
+  const panelRef = useRef(null);
+  const fabRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handleKeyDown(e) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+
+    function handleClickOutside(e) {
+      if (
+        panelRef.current &&
+        !panelRef.current.contains(e.target) &&
+        fabRef.current &&
+        !fabRef.current.contains(e.target)
+      ) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [open]);
 
   return (
     <div className={styles.widget} aria-label="Community actions">
       {open && (
-        <div className={styles.panel} role="dialog" aria-label="Community actions menu">
+        <div
+          ref={panelRef}
+          className={styles.panel}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Community actions menu"
+        >
           <div className={styles.panelHeader}>
             <span className={styles.panelTitle}>Join the Cadence community</span>
             <button
@@ -56,24 +91,33 @@ export default function CommunityWidget() {
             </button>
           </div>
           <ul className={styles.actionList}>
-            {ACTIONS.map((action) => (
-              <li key={action.id}>
-                <a
-                  href={action.href}
-                  className={styles.actionItem}
-                  target={action.external ? '_blank' : undefined}
-                  rel={action.external ? 'noopener noreferrer' : undefined}
-                  onClick={() => setOpen(false)}
-                >
-                  <Icon icon={action.icon} className={styles.actionIcon} width={20} />
-                  <span>{action.label}</span>
-                </a>
-              </li>
-            ))}
+            {ACTIONS.map((action) =>
+              action.external ? (
+                <li key={action.id}>
+                  <a
+                    href={action.href}
+                    className={styles.actionItem}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Icon icon={action.icon} className={styles.actionIcon} width={20} />
+                    <span>{action.label}</span>
+                  </a>
+                </li>
+              ) : (
+                <li key={action.id}>
+                  <Link to={action.href} className={styles.actionItem} onClick={() => setOpen(false)}>
+                    <Icon icon={action.icon} className={styles.actionIcon} width={20} />
+                    <span>{action.label}</span>
+                  </Link>
+                </li>
+              )
+            )}
           </ul>
         </div>
       )}
       <button
+        ref={fabRef}
         className={`${styles.fab} ${open ? styles.fabOpen : ''}`}
         onClick={() => setOpen((v) => !v)}
         aria-label={open ? 'Close community menu' : 'Open community actions'}

--- a/src/theme/CommunityWidget.module.css
+++ b/src/theme/CommunityWidget.module.css
@@ -1,0 +1,123 @@
+.widget {
+  position: fixed;
+  bottom: 1.75rem;
+  right: 1.75rem;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.75rem;
+}
+
+.fab {
+  width: 3.75rem;
+  height: 3.75rem;
+  border-radius: 50%;
+  border: none;
+  background: #2563EB;
+  color: #ffffff;
+  cursor: pointer;
+  box-shadow: 0 4px 20px rgba(37, 99, 235, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
+  flex-shrink: 0;
+}
+
+.fab:hover {
+  transform: scale(1.08);
+  box-shadow: 0 6px 24px rgba(37, 99, 235, 0.55);
+  background: #1D4ED8;
+}
+
+.fabOpen {
+  background: #1e3a5f;
+  box-shadow: 0 4px 20px rgba(30, 58, 95, 0.4);
+}
+
+.panel {
+  background: var(--ifm-card-background-color, #ffffff);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 1rem;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15);
+  min-width: 260px;
+  overflow: hidden;
+}
+
+html[data-theme='dark'] .panel {
+  background: #1e2a3a;
+  border-color: rgba(255,255,255,0.1);
+}
+
+.panelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.9rem 1rem 0.7rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+html[data-theme='dark'] .panelHeader {
+  border-bottom-color: rgba(255,255,255,0.08);
+}
+
+.panelTitle {
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--ifm-font-color-base);
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--ifm-color-emphasis-500);
+  display: flex;
+  align-items: center;
+  padding: 0.2rem;
+  border-radius: 0.25rem;
+  transition: background 0.15s;
+}
+
+.closeButton:hover {
+  background: var(--ifm-color-emphasis-200);
+}
+
+.actionList {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0;
+}
+
+.actionItem {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 1rem;
+  color: var(--ifm-font-color-base);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: background 0.15s;
+}
+
+.actionItem:hover {
+  background: #EFF6FF;
+  color: #1D4ED8;
+  text-decoration: none;
+}
+
+html[data-theme='dark'] .actionItem:hover {
+  background: rgba(37, 99, 235, 0.15);
+  color: #93C5FD;
+}
+
+.actionIcon {
+  color: #2563EB;
+  flex-shrink: 0;
+}
+
+html[data-theme='dark'] .actionIcon {
+  color: #93C5FD;
+}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,9 +1,11 @@
 import React from 'react';
+import CommunityWidget from './CommunityWidget';
 
 export default function Root({ children }) {
   return (
     <>
       {children}
+      <CommunityWidget />
     </>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a `/community/meetup` page with session info, past recordings, and links to all community channels
- Adds a bottom-right floating action button (FAB) widget on every page via Docusaurus Root swizzle, giving one-click access to: community meetup, Slack (CNCF), Discord, GitHub Discussions, and the contact page
- Widget uses `@iconify/react` for crisp white icons on a high-contrast blue button
- Updates `sidebarsCommunity.js` to include the new meetup page

<img width="81" height="81" alt="Screenshot 2026-06-10 at 14 37 31" src="https://github.com/user-attachments/assets/b1d6f702-aa4b-494f-a607-7d9870a73fb6" />
<img width="291" height="396" alt="Screenshot 2026-06-10 at 14 37 56" src="https://github.com/user-attachments/assets/d6272494-0f94-4996-b76f-ca4b7d3ad5e2" />


## Test plan

- [ ] Visit any docs page — FAB appears in bottom-right corner
- [ ] Click FAB — panel opens with all 5 community links
- [ ] Verify links: meetup and contact open in same tab, Slack/Discord/GitHub open in new tab
- [ ] Toggle dark mode — colors adapt correctly
- [ ] Visit `/community/meetup` — page renders with full content and sidebar entry