### PR TITLE
docs(client): rewrite Go and Java child workflow pages

### DIFF
--- a/docs/04-java-client/13-child-workflows.md
+++ b/docs/04-java-client/13-child-workflows.md
@@ -177,8 +177,8 @@ scope.cancel();
 | `setWorkflowId` | No | Stable ID for the child execution. Generated automatically if omitted. |
 | `setDomain` | No | Run the child in a different domain than the parent. |
 | `setTaskList` | No | Route the child to a specific worker pool. Inherits the parent's task list if omitted. |
-| `setExecutionStartToCloseTimeout` | No | Maximum total runtime for the child execution. |
-| `setTaskStartToCloseTimeout` | No | Maximum time for a single decision task. |
+| `setExecutionStartToCloseTimeout` | Conditional | Maximum total runtime for the child execution. A value is required, but it can instead be declared with `executionStartToCloseTimeoutSeconds` on the child's `@WorkflowMethod`. |
+| `setTaskStartToCloseTimeout` | No | Maximum time for a single decision task. Defaults to 10 seconds. |
 | `setWorkflowIdReusePolicy` | No | Whether a completed `WorkflowId` may be reused. |
 | `setRetryOptions` | No | Exponential retry policy applied to the child execution. |
 | `setParentClosePolicy` | No | What happens to the child when the parent closes. See [When the parent closes](#when-the-parent-closes). |

--- a/docs/04-java-client/13-child-workflows.md
+++ b/docs/04-java-client/13-child-workflows.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Child workflows
-description: This page explains how to schedule and manage child workflows from a parent workflow in Java using Cadence, including async execution and lifecycle control.
+description: Schedule and manage child workflows from a parent workflow in Java using Cadence, including async execution, signals, parallel children, options, and parent close policy.
 keywords:
   - cadence child workflow java
   - ExecuteChildWorkflow java
@@ -10,99 +10,194 @@ keywords:
   - cadence child workflow async
   - cadence java child workflow example
   - newChildWorkflowStub java
+  - ParentClosePolicy java
 permalink: /docs/java-client/child-workflows
 ---
 
-Besides :activity:activities:, a :workflow: can also orchestrate other :workflow:workflows:.
+Besides activities, a workflow can also orchestrate other workflows. The orchestrating workflow is the *parent* and the workflow it schedules is the *child*. A child has a lifecycle the parent shapes at every stage: the parent starts it, watches it, communicates with it, and decides its fate when the parent itself closes or is canceled.
 
-`workflow.ExecuteChildWorkflow` enables the scheduling of other :workflow:workflows: from within a :workflow:workflow:'s
-implementation. The parent :workflow: has the ability to monitor and impact the lifecycle of the child
-:workflow:, similar to the way it does for an :activity: that it invoked.
+Child workflows run independently of that relationship in every other respect: each has its own event history, its own timeouts and retry policy, and can run on a different task list and worker pool than the parent. This page follows a child from start to finish.
+
+---
+
+## When to use a child workflow
+
+A child workflow is not always the right tool. Pick the lightest option that fits the work:
+
+| Option | When to use it |
+|--------|----------------|
+| **Activity** | The work is a single non-deterministic operation, such as an API call, a DB write, or sending an email. Activities are retried independently and have the lowest overhead. |
+| **Child Workflow** | You need a reusable, self-contained orchestration with its own event history, timeouts, and retry policy, but whose lifecycle is still tied to the parent. |
+| **Standalone Workflow** | The process is fully independent and shouldn't share the parent's lifecycle. Start it as its own top-level execution with a `WorkflowClient` instead. |
+
+---
+
+## Starting a child
+
+`Workflow.newChildWorkflowStub` returns a client-side stub that implements a child workflow interface. It takes a child workflow type and optional `ChildWorkflowOptions`. Options are needed only to override the timeouts and task list defined on the child's `@WorkflowMethod` annotation or inherited from the parent.
+
+The first call on the stub must be to the method annotated with `@WorkflowMethod`. As with activities, the call can be synchronous or asynchronous via `Async#function` or `Async#procedure`. A synchronous call blocks until the child completes; an asynchronous call returns a `Promise`.
 
 ```java
 public static class GreetingWorkflowImpl implements GreetingWorkflow {
 
   @Override
   public String getGreeting(String name) {
-    // Workflows are stateful. So a new stub must be created for each new child.
+    // Workflows are stateful, so a new stub must be created for each new child.
     GreetingChild child = Workflow.newChildWorkflowStub(GreetingChild.class);
 
-    // This is a non blocking call that returns immediately.
+    // Non-blocking call that returns immediately.
     // Use child.composeGreeting("Hello", name) to call synchronously.
     Promise<String> greeting = Async.function(child::composeGreeting, "Hello", name);
     // Do something else here.
     return greeting.get(); // blocks waiting for the child to complete.
   }
-
-  // This example shows how parent workflow return right after starting a child workflow,
-  // and let the child run itself.
-  private String demoAsyncChildRun(String name) {
-    GreetingChild child = Workflow.newChildWorkflowStub(GreetingChild.class);
-    // non blocking call that initiated child workflow
-    Async.function(child::composeGreeting, "Hello", name);
-    // instead of using greeting.get() to block till child complete,
-    // sometimes we just want to return parent immediately and keep child running
-    Promise<WorkflowExecution> childPromise = Workflow.getWorkflowExecution(child);
-    childPromise.get(); // block until child started,
-    // otherwise child may not start because parent complete first.
-    return "let child run, parent just return";
-  }
 }
 ```
 
-`Workflow.newChildWorkflowStub` returns a client-side stub that implements a child :workflow: interface.
- It takes a child :workflow: type and optional child :workflow: options as arguments. :workflow:Workflow: options may be needed to override
- the timeouts and :task_list: if they differ from the ones defined in the `@WorkflowMethod` annotation or parent :workflow:.
+Starting a child only *schedules* it. The child is not actually created until the parent yields control back to Cadence. This matters when the parent may finish quickly (see [When the parent closes](#when-the-parent-closes)).
 
- The first call to the child :workflow: stub must always be to a method annotated with `@WorkflowMethod`. Similar to :activity:activities:, a call
- can be made synchronous or asynchronous by using `Async#function` or `Async#procedure`. The synchronous call blocks until a child :workflow: completes. The asynchronous call
- returns a `Promise` that can be used to wait for the completion. After an async call returns the stub, it can be used to send :signal:signals: to the child
- by calling methods annotated with `@SignalMethod`. :query:Querying: a child :workflow: by calling methods annotated with `@QueryMethod`
- from within :workflow: code is not supported. However, :query:queries: can be done from :activity:activities:
- using the provided `WorkflowClient` stub.
+---
 
- Running two children in parallel:
- ```java
- public static class GreetingWorkflowImpl implements GreetingWorkflow {
+## Monitoring and communicating
 
-     @Override
-     public String getGreeting(String name) {
+An asynchronous call returns a `Promise`; block on it only when the parent needs the result.
 
-         // Workflows are stateful, so a new stub must be created for each new child.
-         GreetingChild child1 = Workflow.newChildWorkflowStub(GreetingChild.class);
-         Promise<String> greeting1 = Async.function(child1::composeGreeting, "Hello", name);
+To let a child keep running while the parent returns, block until the child has *started* first. Otherwise the parent may complete before the child is scheduled:
 
-         // Both children will run concurrently.
-         GreetingChild child2 = Workflow.newChildWorkflowStub(GreetingChild.class);
-         Promise<String> greeting2 = Async.function(child2::composeGreeting, "Bye", name);
+```java
+private String demoAsyncChildRun(String name) {
+  GreetingChild child = Workflow.newChildWorkflowStub(GreetingChild.class);
+  // Non-blocking call that initiates the child workflow.
+  Async.function(child::composeGreeting, "Hello", name);
+  // Block until the child has started, otherwise it may not start
+  // because the parent completes first.
+  Promise<WorkflowExecution> childPromise = Workflow.getWorkflowExecution(child);
+  childPromise.get();
+  return "let child run, parent just return";
+}
+```
 
-         // Do something else here.
-         ...
-         return "First: " + greeting1.get() + ", second: " + greeting2.get();
-     }
- }
- ```
+**Run children in parallel** by creating a separate stub per child and starting each asynchronously. The children run concurrently; block on each `Promise` when you need its result.
 
+```java
+GreetingChild child1 = Workflow.newChildWorkflowStub(GreetingChild.class);
+Promise<String> greeting1 = Async.function(child1::composeGreeting, "Hello", name);
 
- To send a :signal: to a child, call a method annotated with `@SignalMethod`:
- ```java
- public interface GreetingChild {
-     @WorkflowMethod
-     String composeGreeting(String greeting, String name);
+GreetingChild child2 = Workflow.newChildWorkflowStub(GreetingChild.class);
+Promise<String> greeting2 = Async.function(child2::composeGreeting, "Bye", name);
 
-     @SignalMethod
-     void updateName(String name);
- }
+return "First: " + greeting1.get() + ", second: " + greeting2.get();
+```
 
- public static class GreetingWorkflowImpl implements GreetingWorkflow {
+**Signal a running child** by calling a method annotated with `@SignalMethod` on the stub after the async call returns.
 
-     @Override
-     public String getGreeting(String name) {
-         GreetingChild child = Workflow.newChildWorkflowStub(GreetingChild.class);
-         Promise<String> greeting = Async.function(child::composeGreeting, "Hello", name);
-         child.updateName("Cadence");
-         return greeting.get();
-     }
- }
- ```
- Calling methods annotated with `@QueryMethod` is not allowed from within :workflow: code.
+```java
+public interface GreetingChild {
+    @WorkflowMethod
+    String composeGreeting(String greeting, String name);
+
+    @SignalMethod
+    void updateName(String name);
+}
+
+// In the parent:
+GreetingChild child = Workflow.newChildWorkflowStub(GreetingChild.class);
+Promise<String> greeting = Async.function(child::composeGreeting, "Hello", name);
+child.updateName("Cadence");
+return greeting.get();
+```
+
+:::note Queries cannot be issued from workflow code
+Calling `@QueryMethod` methods on a child from within workflow code is not supported. Run queries from an activity or external process using a `WorkflowClient` stub instead.
+:::
+
+---
+
+## When the parent closes
+
+`ParentClosePolicy` decides what Cadence does to a still-running child when the **parent closes**, whether the parent completes, fails, times out, or is terminated. It is set per child on `ChildWorkflowOptions`.
+
+| Policy | Java enum | Behavior |
+|--------|-----------|----------|
+| **Terminate** (default) | `ParentClosePolicy.TERMINATE` | The child is terminated immediately when the parent closes. |
+| **Request cancel** | `ParentClosePolicy.REQUEST_CANCEL` | A cancellation request is sent to the child, giving it a chance to run cleanup before exiting. |
+| **Abandon** | `ParentClosePolicy.ABANDON` | The child keeps running independently after the parent closes. |
+
+Use **abandon** for children that are meant to outlive their parent. For example, a long-running detached process started by a short-lived orchestrator.
+
+```java
+import com.uber.cadence.ParentClosePolicy;
+
+ChildWorkflowOptions options = new ChildWorkflowOptions.Builder()
+    .setWorkflowId("detached-child")
+    .setParentClosePolicy(ParentClosePolicy.ABANDON)
+    .build();
+
+GreetingChild child = Workflow.newChildWorkflowStub(GreetingChild.class, options);
+Async.function(child::composeGreeting, "Hello", name);
+
+// Block until the child has started before the parent returns.
+Workflow.getWorkflowExecution(child).get();
+```
+
+:::caution Wait for an abandoned child to start before the parent returns
+A child is only scheduled once the parent yields control to Cadence. If the parent completes before the child has started, the child may never run, which defeats the purpose of `ABANDON`. Always block on `Workflow.getWorkflowExecution(child).get()` before returning from the parent, as shown in [Monitoring and communicating](#monitoring-and-communicating).
+:::
+
+:::note Default is terminate
+If you do not call `setParentClosePolicy`, children are terminated when the parent closes. Set it explicitly whenever a child should survive or shut down gracefully.
+:::
+
+---
+
+## Cancelling a child
+
+Closing is not the only way a child ends early. A child runs inside a `CancellationScope`; cancel the scope to request cancellation of every child started within it.
+
+```java
+CancellationScope scope = Workflow.newCancellationScope(() -> {
+    GreetingChild child = Workflow.newChildWorkflowStub(GreetingChild.class);
+    Async.function(child::composeGreeting, "Hello", name);
+});
+scope.run();
+
+// Request cancellation of everything started inside the scope, including the child.
+scope.cancel();
+```
+
+---
+
+## Child workflow options
+
+`ChildWorkflowOptions` controls the child's identity, routing, and lifecycle. Most fields are optional and inherit sensible defaults from the parent or the child's annotations.
+
+| Builder method | Required | Purpose |
+|----------------|----------|---------|
+| `setWorkflowId` | No | Stable ID for the child execution. Generated automatically if omitted. |
+| `setDomain` | No | Run the child in a different domain than the parent. |
+| `setTaskList` | No | Route the child to a specific worker pool. Inherits the parent's task list if omitted. |
+| `setExecutionStartToCloseTimeout` | No | Maximum total runtime for the child execution. |
+| `setTaskStartToCloseTimeout` | No | Maximum time for a single decision task. |
+| `setWorkflowIdReusePolicy` | No | Whether a completed `WorkflowId` may be reused. |
+| `setRetryOptions` | No | Exponential retry policy applied to the child execution. |
+| `setParentClosePolicy` | No | What happens to the child when the parent closes. See [When the parent closes](#when-the-parent-closes). |
+
+---
+
+## Samples
+
+Runnable child-workflow samples:
+
+| Sample | Description | Code |
+|--------|-------------|------|
+| **Child workflow** | Parent starts a child, waits for its result | [HelloChild.java](https://github.com/cadence-workflow/cadence-java-samples/blob/master/src/main/java/com/uber/cadence/samples/hello/HelloChild.java) |
+| **Child cancellation** | Parent cancels a running child | [HelloCancelChild.java](https://github.com/cadence-workflow/cadence-java-samples/blob/master/src/main/java/com/uber/cadence/samples/hello/HelloCancelChild.java) |
+
+---
+
+## References
+
+- Java SDK Javadoc: [Child Workflows](https://javadoc.io/doc/com.uber.cadence/cadence-client/latest/com/uber/cadence/workflow/Workflow.html)
+- Java SDK Javadoc: [ChildWorkflowOptions](https://javadoc.io/doc/com.uber.cadence/cadence-client/latest/com/uber/cadence/workflow/ChildWorkflowOptions.html)
+- [Workflows](/docs/concepts/workflows): workflow semantics, IDs, retries

--- a/docs/05-go-client/06-child-workflows.md
+++ b/docs/05-go-client/06-child-workflows.md
@@ -117,8 +117,9 @@ Use **abandon** for children that are meant to outlive their parent. For example
 import "go.uber.org/cadence/client"
 
 cwo := workflow.ChildWorkflowOptions{
-    WorkflowID:        "detached-child",
-    ParentClosePolicy: client.ParentClosePolicyAbandon,
+    WorkflowID:                   "detached-child",
+    ExecutionStartToCloseTimeout: time.Minute * 30,
+    ParentClosePolicy:            client.ParentClosePolicyAbandon,
 }
 ctx = workflow.WithChildOptions(ctx, cwo)
 
@@ -146,8 +147,9 @@ Closing is not the only way a child ends early. A child is also canceled when th
 
 ```go
 cwo := workflow.ChildWorkflowOptions{
-    WorkflowID:          "cancellable-child",
-    WaitForCancellation: true,
+    WorkflowID:                   "cancellable-child",
+    ExecutionStartToCloseTimeout: time.Minute * 30,
+    WaitForCancellation:          true,
 }
 ctx = workflow.WithChildOptions(ctx, cwo)
 

--- a/docs/05-go-client/06-child-workflows.md
+++ b/docs/05-go-client/06-child-workflows.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Child workflows
-description: This page explains how to schedule and manage child workflows from a parent workflow in Go using workflow.ExecuteChildWorkflow, including options configuration and lifecycle control.
+description: Schedule and manage child workflows from a parent workflow in Go using workflow.ExecuteChildWorkflow, including options, signals, parallel execution, and parent close policy.
 keywords:
   - cadence child workflow go
   - workflow.ExecuteChildWorkflow go
@@ -10,60 +10,188 @@ keywords:
   - cadence parent child workflow go
   - cadence golang child workflow example
   - ChildWorkflowOptions go
+  - ParentClosePolicy go
 permalink: /docs/go-client/child-workflows
 ---
 
-`workflow.ExecuteChildWorkflow` enables the scheduling of other :workflow:workflows: from within a :workflow:workflow:'s
-implementation. The parent :workflow: has the ability to monitor and impact the lifecycle of the child
-:workflow:, similar to the way it does for an :activity: that it invoked.
+`workflow.ExecuteChildWorkflow` schedules another workflow from inside a running workflow. The scheduling workflow is the *parent* and the scheduled workflow is the *child*. A child has a lifecycle the parent shapes at every stage: the parent starts it, watches it, communicates with it, and decides its fate when the parent itself closes or is canceled.
+
+Child workflows run independently of that relationship in every other respect: each has its own event history, its own timeouts and retry policy, and can run on a different task list and worker pool than the parent. This page follows a child from start to finish.
+
+---
+
+## When to use a child workflow
+
+A child workflow is not always the right tool. Pick the lightest option that fits the work:
+
+| Option | When to use it |
+|--------|----------------|
+| **Activity** | The work is a single non-deterministic operation, such as an API call, a DB write, or sending an email. Activities are retried independently and have the lowest overhead. |
+| **Child Workflow** | You need a reusable, self-contained orchestration with its own event history, timeouts, and retry policy, but whose lifecycle is still tied to the parent. |
+| **Standalone Workflow** | The process is fully independent and shouldn't share the parent's lifecycle. Start it as its own top-level execution with a `WorkflowClient` instead. |
+
+---
+
+## Starting a child
+
+Configure `ChildWorkflowOptions`, derive a child context from the parent context, then call `workflow.ExecuteChildWorkflow`. The call returns immediately with a `workflow.ChildWorkflowFuture`.
 
 ```go
 cwo := workflow.ChildWorkflowOptions{
-    // Do not specify WorkflowID if you want Cadence to generate a unique ID for the child execution.
+    // Omit WorkflowID to let Cadence generate a unique ID for the child execution.
     WorkflowID:                   "BID-SIMPLE-CHILD-WORKFLOW",
     ExecutionStartToCloseTimeout: time.Minute * 30,
 }
 ctx = workflow.WithChildOptions(ctx, cwo)
 
-var result string
 future := workflow.ExecuteChildWorkflow(ctx, SimpleChildWorkflow, value)
+```
+
+The second argument is the registered workflow function. You can also pass its fully qualified name as a string, but passing the function lets the framework validate the parameter types. The remaining arguments are forwarded to the child and must match the child's signature.
+
+Starting a child only *schedules* it. The child is not actually created until the parent yields control back to Cadence. This matters when the parent may finish quickly (see [When the parent closes](#when-the-parent-closes)).
+
+---
+
+## Monitoring and communicating
+
+Because the start call returns a future, the parent can keep working and block on the result only when it needs it.
+
+```go
+var result string
 if err := future.Get(ctx, &result); err != nil {
     workflow.GetLogger(ctx).Error("SimpleChildWorkflow failed.", zap.Error(err))
     return err
 }
 ```
-Let's take a look at each component of this call.
 
-Before calling `workflow.ExecuteChildWorkflow()`, you must configure `ChildWorkflowOptions` for the
-invocation. These options customize various execution timeouts, and are passed in by creating a child
-context from the initial context and overwriting the desired values. The child context is then passed
-into the `workflow.ExecuteChildWorkflow()` call. If multiple child :workflow:workflows: are sharing the same option
-values, then the same context instance can be used when calling `workflow.ExecuteChildWorkflow()`.
+**Run children in parallel** by giving each its own future, then blocking on the results. The children run concurrently.
 
-The first parameter in the call is the required `cadence.Context` object. This type is a copy of
-`context.Context` with the `Done()` method returning `cadence.Channel` instead of the native Go `chan`.
+```go
+child1 := workflow.ExecuteChildWorkflow(ctx, GreetingChild, "Hello", name)
+child2 := workflow.ExecuteChildWorkflow(ctx, GreetingChild, "Bye", name)
 
-The second parameter is the function that we registered as a :workflow: function. This parameter can
-also be a string representing the fully qualified name of the :workflow: function. The benefit of this
-is that when you pass in the actual function object, the framework can validate :workflow: parameters.
+var greeting1, greeting2 string
+if err := child1.Get(ctx, &greeting1); err != nil {
+    return err
+}
+if err := child2.Get(ctx, &greeting2); err != nil {
+    return err
+}
+```
 
-The remaining parameters are passed to the :workflow: as part of the call. In our example, we have a
-single parameter: `value`. This list of parameters must match the list of parameters declared by
-the :workflow: function.
+**Signal a running child** by resolving its execution from the future, then calling `workflow.SignalExternalWorkflow`.
 
-The method call returns immediately and returns a `cadence.Future`. This allows you to execute more
-code without having to wait for the scheduled :workflow: to complete.
+```go
+var childWE workflow.Execution
+if err := future.GetChildWorkflowExecution().Get(ctx, &childWE); err != nil {
+    return err
+}
 
-When you are ready to process the results of the :workflow:, call the `Get()` method on the returned future
-object. The parameters to this method are the `ctx` object we passed to the
-`workflow.ExecuteChildWorkflow()` call and an output parameter that will receive the output of the
-:workflow:. The type of the output parameter must match the type of the return value declared by the
-:workflow: function. The `Get()` method will block until the :workflow: completes and results are
-available.
+if err := workflow.SignalExternalWorkflow(
+    ctx, childWE.ID, childWE.RunID, "updateName", "Cadence",
+).Get(ctx, nil); err != nil {
+    return err
+}
+```
 
-The `workflow.ExecuteChildWorkflow()` function is similar to `workflow.ExecuteActivity()`. All of the
-patterns described for using `workflow.ExecuteActivity()` apply to the `workflow.ExecuteChildWorkflow()`
-function as well.
+:::note Queries cannot be issued from workflow code
+A parent cannot query a child from within workflow code. Run queries from an activity or external process using a `WorkflowClient` stub instead.
+:::
 
-When a parent :workflow: is cancelled by the user, the child :workflow: can be cancelled or abandoned
-based on a configurable child policy.
+---
+
+## When the parent closes
+
+`ParentClosePolicy` decides what Cadence does to a still-running child when the **parent closes**, whether the parent completes, fails, times out, or is terminated. It is set per child on `ChildWorkflowOptions`.
+
+| Policy | Go constant | Behavior |
+|--------|-------------|----------|
+| **Terminate** (default) | `client.ParentClosePolicyTerminate` | The child is terminated immediately when the parent closes. |
+| **Request cancel** | `client.ParentClosePolicyRequestCancel` | A cancellation request is sent to the child, giving it a chance to run cleanup before exiting. |
+| **Abandon** | `client.ParentClosePolicyAbandon` | The child keeps running independently after the parent closes. |
+
+Use **abandon** for children that are meant to outlive their parent. For example, a long-running detached process started by a short-lived orchestrator.
+
+```go
+import "go.uber.org/cadence/client"
+
+cwo := workflow.ChildWorkflowOptions{
+    WorkflowID:        "detached-child",
+    ParentClosePolicy: client.ParentClosePolicyAbandon,
+}
+ctx = workflow.WithChildOptions(ctx, cwo)
+
+future := workflow.ExecuteChildWorkflow(ctx, SimpleChildWorkflow, value)
+
+// Block until the child has actually started before the parent returns.
+if err := future.GetChildWorkflowExecution().Get(ctx, nil); err != nil {
+    return err
+}
+```
+
+:::caution Wait for an abandoned child to start before the parent returns
+A child is only scheduled once the parent yields control to Cadence. If the parent completes before the child has started, the child may never run, which defeats the purpose of `ABANDON`. Always block on `future.GetChildWorkflowExecution().Get(ctx, nil)` before returning from the parent.
+:::
+
+:::note Default is terminate
+If you do not set `ParentClosePolicy`, children are terminated when the parent closes. Set it explicitly whenever a child should survive or shut down gracefully.
+:::
+
+---
+
+## Cancelling a child
+
+Closing is not the only way a child ends early. A child is also canceled when the parent's workflow context is canceled, or explicitly via `workflow.RequestCancelExternalWorkflow`. By default the parent does not wait for the child to finish reacting; set `WaitForCancellation: true` if the parent should block until the child has fully exited.
+
+```go
+cwo := workflow.ChildWorkflowOptions{
+    WorkflowID:          "cancellable-child",
+    WaitForCancellation: true,
+}
+ctx = workflow.WithChildOptions(ctx, cwo)
+
+childCtx, cancel := workflow.WithCancel(ctx)
+future := workflow.ExecuteChildWorkflow(childCtx, SimpleChildWorkflow, value)
+
+// Cancel the child; because WaitForCancellation is true, the parent blocks until it exits.
+cancel()
+_ = future.Get(ctx, nil)
+```
+
+---
+
+## Child workflow options
+
+`ChildWorkflowOptions` controls the child's identity, routing, and lifecycle. Most fields are optional and inherit sensible defaults from the parent.
+
+| Field | Required | Purpose |
+|-------|----------|---------|
+| `WorkflowID` | No | Stable ID for the child execution. Generated automatically if omitted. |
+| `Domain` | No | Run the child in a different domain than the parent. |
+| `TaskList` | No | Route the child to a specific worker pool. Inherits the parent's task list if omitted. |
+| `ExecutionStartToCloseTimeout` | Yes | Maximum total runtime for the child execution. |
+| `TaskStartToCloseTimeout` | No | Maximum time for a single decision task. |
+| `WorkflowIDReusePolicy` | No | Whether a completed `WorkflowID` may be reused. |
+| `RetryPolicy` | No | Exponential retry policy applied to the child execution. |
+| `WaitForCancellation` | No | If `true`, the parent waits for the child to finish reacting to a cancellation. See [Cancelling a child](#cancelling-a-child). |
+| `ParentClosePolicy` | No | What happens to the child when the parent closes. See [When the parent closes](#when-the-parent-closes). |
+
+---
+
+## Samples
+
+Runnable child-workflow samples:
+
+| Sample | Description | Code |
+|--------|-------------|------|
+| **Child workflow** | Parent starts a child, waits for its result | [Go source](https://github.com/cadence-workflow/cadence-samples/tree/master/new_samples/childworkflow) |
+| **Child cancellation** | Parent cancels a running child | [Recipe](https://github.com/cadence-workflow/cadence-samples/tree/master/cmd/samples/recipes/childworkflow) |
+
+---
+
+## References
+
+- Go SDK godoc: [Child Workflows](https://pkg.go.dev/go.uber.org/cadence/workflow#hdr-Child_Workflow)
+- Go SDK godoc: [ChildWorkflowOptions](https://pkg.go.dev/go.uber.org/cadence/workflow#ChildWorkflowOptions)
+- [Workflows](/docs/concepts/workflows): workflow semantics, IDs, retries


### PR DESCRIPTION
**What changed?**

Rewrote the Go (`docs/05-go-client/06-child-workflows.md`) and Java (`docs/04-java-client/13-child-workflows.md`) child workflow pages into sectioned, scannable docs, and documented `ParentClosePolicy` for the first time.

- Added `##` sections (When to use, Starting, Monitoring/communicating, When the parent closes, Cancelling, Options, Samples, References) so each page now has a right-rail outline.
- New `ParentClosePolicy` section: `ABANDON` / `REQUEST_CANCEL` / `TERMINATE` table, default-terminate note, abandon code sample, and a caution to block until the child has started.
- Added a "When to use a child workflow" decision table, a `ChildWorkflowOptions` reference table, and a Samples table linking the real Go/Java samples.

**Why?**

- The previous pages were a single unsectioned blob with no on-page outline.
- ParentClosePolicy` was effectively undocumented (one vague sentence on the Go page, nothing on Java). 

This brings both pages in line with the recently rewritten concept docs and gives readers the parent-close behavior they currently have to find in the SDK source.

**How did you verify it?**

- [x] Ran production preview (`npm run preview:github-pages -- --serve`)
- [x] Checked dark mode and light mode on affected pages

**Potential risks**

- Outbound links: godoc anchors (`workflow#hdr-Child_Workflow`, `workflow#ChildWorkflowOptions`) and javadoc/sample links.

**Related changes**

N/A (standalone docs improvement).