### PR TITLE
docs: add Schedules concept page and announcement blog post

### DIFF
--- a/blog/2026-06-23-cadence-schedules.md
+++ b/blog/2026-06-23-cadence-schedules.md
@@ -1,0 +1,122 @@
+---
+title: "Introducing Cadence Schedules"
+description: Cadence Schedules bring first-class recurring workflow execution to the platform — with overlap policies, backfill, pause/unpause, and full observability, all without touching your workflow code.
+keywords:
+  - cadence schedules
+  - cadence recurring workflow
+  - cadence schedule workflow
+  - cadence cron alternative
+  - cadence overlap policy
+  - cadence backfill schedule
+  - cadence pause resume schedule
+  - cadence scheduler
+  - workflow scheduling cadence
+date: 2026-06-23
+authors: abhishekj720
+tags:
+  - announcement
+  - deep-dive
+---
+
+Cadence has had cron-based scheduling since early on via the `CronSchedule` field on `StartWorkflowOptions`. It works, but it is embedded in the workflow at start time — you cannot pause it, inspect its history, update its spec, or backfill missed runs without cancelling and restarting the workflow entirely.
+
+Schedules fix all of that.
+
+<!-- truncate -->
+
+## What are Schedules?
+
+A Schedule is a first-class server-side object in Cadence. You create one with a cron expression and a workflow action. The Cadence server runs a durable internal scheduler workflow that fires your target workflow on each tick — surviving restarts, failures, and rollouts just like any other workflow.
+
+Your target workflow does not need to know it is being run by a schedule. It is a plain workflow. The scheduler handles the timing, the overlap logic, and the observability.
+
+## Overlap policies
+
+The most common operational headache with cron-based scheduling is: what happens when the next fire is due but the previous run is still going?
+
+With the old `CronSchedule`, the answer was always: skip. Schedules give you a choice:
+
+| Policy | What happens |
+|---|---|
+| `SKIP_NEW` (default) | The new fire is dropped; the current run continues. |
+| `BUFFER_ONE` | The new fire is queued. It starts as soon as the current run finishes. |
+| `CANCEL_PREVIOUS` | The current run receives a cancellation signal; the new run starts. |
+| `TERMINATE_PREVIOUS` | The current run is forcibly terminated; the new run starts immediately. |
+| `ALLOW_ALL` | Every fire starts unconditionally, regardless of how many runs are active. |
+
+You can change the overlap policy on a live schedule via `UpdateSchedule` without interrupting anything that is already running.
+
+## Backfill
+
+If your schedule was paused during a maintenance window, or if a bug meant runs were skipped, backfill lets you request fires for any historical time range:
+
+```bash
+cadence schedule backfill \
+  --schedule_id my-schedule \
+  --start_time "2026-06-01T00:00:00Z" \
+  --end_time   "2026-06-10T00:00:00Z" \
+  --backfill_id backfill-june-gap
+```
+
+Each backfilled run is tagged with search attributes so you can distinguish it from normal scheduled runs in queries.
+
+## Pause and unpause
+
+Pausing a schedule suspends all new fires. You can attach a note explaining why — useful for linking to an incident ticket or a change freeze notice.
+
+```bash
+cadence schedule pause \
+  --schedule_id my-schedule \
+  --reason "INFRA-4421: cluster maintenance 2026-06-22"
+
+cadence schedule unpause --schedule_id my-schedule
+```
+
+Unpausing resumes from the current time. Missed fires during the pause window are not replayed automatically — use backfill if you need them.
+
+## Observability
+
+`DescribeSchedule` returns everything you need to understand the current state of a schedule:
+
+- Cron expression and overlap policy
+- Whether it is paused and the pause note
+- Recent run history — last started and last completed times
+- The next scheduled fire time
+
+```bash
+cadence schedule describe --schedule_id my-schedule
+```
+
+## Catch-up on restart
+
+If the Cadence server is unavailable long enough that fires are missed, the scheduler catches up when it comes back — dispatching missed fires within a configurable window (default: one year). Fires older than the window are dropped. The scheduler uses the schedule's creation time as the earliest catch-up point, so a brand-new schedule will never dispatch phantom fires from before it existed.
+
+## How it compares to distributed cron
+
+|  | Schedules | `CronSchedule` field |
+|---|---|---|
+| Server-side object | Yes | No |
+| Overlap policy | Configurable | Always skip |
+| Pause/unpause | Yes | No |
+| Backfill | Yes | No |
+| Update without restart | Yes | No |
+| Run history | Yes | No |
+
+For new use cases, use Schedules. `CronSchedule` stays available for backwards compatibility.
+
+## Getting started
+
+Create a schedule from the CLI:
+
+```bash
+cadence schedule create \
+  --schedule_id daily-report \
+  --cron "0 9 * * *" \
+  --workflow_type GenerateDailyReport \
+  --tasklist report-workers \
+  --execution_timeout 3600
+```
+
+SDK support for Go, Java, and Python is on the way. For now, the full API surface is available through the CLI and directly via the Cadence frontend API.
+
+See the [Schedules concept page](/docs/concepts/schedules) for the full reference.

--- a/blog/2026-06-23-cadence-schedules.md
+++ b/blog/2026-06-23-cadence-schedules.md
@@ -41,31 +41,31 @@ Back to the ETL example. You have five reasonable answers depending on what the 
 **Skip the new fire.** The current run is more important. Let it finish; drop the one that arrived early.
 
 ```
---overlap_policy skipnew
+--overlap_policy SkipNew
 ```
 
 **Buffer it.** The new fire matters, but it can wait. Start it the moment the current run finishes.
 
 ```
---overlap_policy buffer
+--overlap_policy Buffer
 ```
 
 **Cancel the current run and start fresh.** The new data has made the current run stale. Request cancellation and proceed.
 
 ```
---overlap_policy cancelprevious
+--overlap_policy CancelPrevious
 ```
 
 **Terminate immediately.** No time for cleanup. Stop the current run hard and start the new one now.
 
 ```
---overlap_policy terminateprevious
+--overlap_policy TerminatePrevious
 ```
 
 **Run them all -- up to a limit.** The job is embarrassingly parallel and you want throughput, but not unbounded throughput. Cap the concurrency at a safe level.
 
 ```
---overlap_policy concurrent --concurrency_limit 5
+--overlap_policy Concurrent --concurrency_limit 5
 ```
 
 That last one is worth pausing on. Most scheduling systems treat concurrent execution as binary: either one at a time, or fully unlimited. With Cadence Schedules, bounded concurrency is a first-class policy. You set the cap; the scheduler enforces it. Fires that arrive when the cap is full are counted as skipped. Set `--concurrency_limit 0` if you want truly unlimited concurrency.

--- a/blog/2026-06-23-cadence-schedules.md
+++ b/blog/2026-06-23-cadence-schedules.md
@@ -1,6 +1,6 @@
 ---
 title: "Introducing Cadence Schedules"
-description: Cadence Schedules bring first-class recurring workflow execution to the platform — with overlap policies, backfill, pause/unpause, and full observability, all without touching your workflow code.
+description: Cadence Schedules bring first-class recurring workflow execution to the platform with overlap policies, backfill, pause/unpause, and full observability, all without touching your workflow code.
 keywords:
   - cadence schedules
   - cadence recurring workflow
@@ -18,105 +18,133 @@ tags:
   - deep-dive
 ---
 
-Cadence has had cron-based scheduling since early on via the `CronSchedule` field on `StartWorkflowOptions`. It works, but it is embedded in the workflow at start time — you cannot pause it, inspect its history, update its spec, or backfill missed runs without cancelling and restarting the workflow entirely.
+Your nightly ETL job takes 90 minutes. The schedule fires every hour. What should happen?
 
-Schedules fix all of that.
+With traditional cron, the answer is: both run, you deal with the fallout. With `CronSchedule` on `StartWorkflowOptions`, the answer was always: the new fire is skipped. Neither answer is right for every situation, and neither lets you change your mind without cancelling and restarting the workflow entirely.
+
+Cadence Schedules give you control.
 
 <!-- truncate -->
 
-## What are Schedules?
+## What is a Schedule?
 
-A Schedule is a first-class server-side object in Cadence. You create one with a cron expression and a workflow action. The Cadence server runs a durable internal scheduler workflow that fires your target workflow on each tick — surviving restarts, failures, and rollouts just like any other workflow.
+A Schedule is a first-class server-side object that manages recurring workflow execution on your behalf. You create it once with a cron expression and a workflow action. Cadence runs a durable internal scheduler workflow that fires your target workflow on each tick, surviving server restarts and failures just like any other Cadence workflow.
 
-Your target workflow does not need to know it is being run by a schedule. It is a plain workflow. The scheduler handles the timing, the overlap logic, and the observability.
+Your target workflow does not need to know it is being scheduled. It is a plain workflow. The scheduler handles the timing, overlap logic, and observability.
+
+This is a meaningful shift from `CronSchedule`. With `CronSchedule`, the schedule is baked into the workflow at start time -- opaque to the server, invisible to operators, impossible to modify without a restart. A Schedule is something you can observe, pause, update, and backfill without touching workflow code.
 
 ## Overlap policies
 
-The most common operational headache with cron-based scheduling is: what happens when the next fire is due but the previous run is still going?
+Back to the ETL example. You have five reasonable answers depending on what the workflow does:
 
-With the old `CronSchedule`, the answer was always: skip. Schedules give you a choice:
+**Skip the new fire.** The current run is more important. Let it finish; drop the one that arrived early.
 
-| Policy | What happens |
-|---|---|
-| `SKIP_NEW` (default) | The new fire is dropped; the current run continues. |
-| `BUFFER_ONE` | The new fire is queued. It starts as soon as the current run finishes. |
-| `CANCEL_PREVIOUS` | The current run receives a cancellation signal; the new run starts. |
-| `TERMINATE_PREVIOUS` | The current run is forcibly terminated; the new run starts immediately. |
-| `ALLOW_ALL` | Every fire starts unconditionally, regardless of how many runs are active. |
-
-You can change the overlap policy on a live schedule via `UpdateSchedule` without interrupting anything that is already running.
-
-## Backfill
-
-If your schedule was paused during a maintenance window, or if a bug meant runs were skipped, backfill lets you request fires for any historical time range:
-
-```bash
-cadence schedule backfill \
-  --schedule_id my-schedule \
-  --start_time "2026-06-01T00:00:00Z" \
-  --end_time   "2026-06-10T00:00:00Z" \
-  --backfill_id backfill-june-gap
+```
+--overlap_policy skipnew
 ```
 
-Each backfilled run is tagged with search attributes so you can distinguish it from normal scheduled runs in queries.
+**Buffer it.** The new fire matters, but it can wait. Start it the moment the current run finishes.
 
-## Pause and unpause
+```
+--overlap_policy buffer
+```
 
-Pausing a schedule suspends all new fires. You can attach a note explaining why — useful for linking to an incident ticket or a change freeze notice.
+**Cancel the current run and start fresh.** The new data has made the current run stale. Request cancellation and proceed.
+
+```
+--overlap_policy cancelprevious
+```
+
+**Terminate immediately.** No time for cleanup. Stop the current run hard and start the new one now.
+
+```
+--overlap_policy terminateprevious
+```
+
+**Run them all -- up to a limit.** The job is embarrassingly parallel and you want throughput, but not unbounded throughput. Cap the concurrency at a safe level.
+
+```
+--overlap_policy concurrent --concurrency_limit 5
+```
+
+That last one is worth pausing on. Most scheduling systems treat concurrent execution as binary: either one at a time, or fully unlimited. With Cadence Schedules, bounded concurrency is a first-class policy. You set the cap; the scheduler enforces it. Fires that arrive when the cap is full are counted as skipped. Set `--concurrency_limit 0` if you want truly unlimited concurrency.
+
+The overlap policy can be changed on a live schedule at any time. The change applies to future fires only; in-flight runs continue under the policy that was active when they started.
+
+## Pause and unpause with context
+
+Pausing a schedule is one operation. Adding context to it is another. With Cadence Schedules they happen together:
 
 ```bash
 cadence schedule pause \
-  --schedule_id my-schedule \
-  --reason "INFRA-4421: cluster maintenance 2026-06-22"
-
-cadence schedule unpause --schedule_id my-schedule
+  --schedule_id daily-etl \
+  --reason "INFRA-4421: cluster maintenance, resume after 2026-06-24 08:00 UTC"
 ```
 
-Unpausing resumes from the current time. Missed fires during the pause window are not replayed automatically — use backfill if you need them.
-
-## Observability
-
-`DescribeSchedule` returns everything you need to understand the current state of a schedule:
-
-- Cron expression and overlap policy
-- Whether it is paused and the pause note
-- Recent run history — last started and last completed times
-- The next scheduled fire time
+When someone runs `describe` a week later, they see exactly why the schedule is paused. No digging through Slack history.
 
 ```bash
-cadence schedule describe --schedule_id my-schedule
+cadence schedule unpause --schedule_id daily-etl
 ```
 
-## Catch-up on restart
+Unpausing resumes from the current time. Fires missed during the pause window are not replayed automatically.
 
-If the Cadence server is unavailable long enough that fires are missed, the scheduler catches up when it comes back — dispatching missed fires within a configurable window (default: one year). Fires older than the window are dropped. The scheduler uses the schedule's creation time as the earliest catch-up point, so a brand-new schedule will never dispatch phantom fires from before it existed.
+## Backfill missed runs
+
+If fires were missed during a pause or an outage, backfill lets you request them explicitly for any historical time range:
+
+```bash
+cadence schedule backfill \
+  --schedule_id daily-etl \
+  --start_time "2026-06-20T00:00:00Z" \
+  --end_time   "2026-06-23T00:00:00Z" \
+  --backfill_id backfill-maintenance-gap
+```
+
+Each backfilled run is tagged with search attributes marking it as a backfill and recording the backfill ID. You can query for backfill runs separately from normal scheduled runs in visibility.
+
+## Catch-up after server downtime
+
+If the Cadence server is unavailable long enough that fires are missed, the scheduler catches up when it recovers. By default it looks back up to one year and dispatches missed fires according to the configured overlap policy. Fires older than the window are dropped.
+
+The scheduler uses the schedule's creation time as the earliest possible catch-up point. A newly created schedule will never dispatch phantom fires for time before it existed.
+
+## Full observability
+
+At any point you can ask the server for the full state of a schedule:
+
+```bash
+cadence schedule describe --schedule_id daily-etl
+```
+
+This returns the cron expression, overlap policy, pause state and note, the last time a workflow was started, the last time one completed, and the next scheduled fire time. No guessing, no log-digging.
 
 ## How it compares to distributed cron
 
-|  | Schedules | `CronSchedule` field |
+| | Schedules | `CronSchedule` field |
 |---|---|---|
 | Server-side object | Yes | No |
 | Overlap policy | Configurable | Always skip |
-| Pause/unpause | Yes | No |
+| Bounded concurrency | Yes | No |
+| Pause/unpause with notes | Yes | No |
 | Backfill | Yes | No |
 | Update without restart | Yes | No |
 | Run history | Yes | No |
 
-For new use cases, use Schedules. `CronSchedule` stays available for backwards compatibility.
+For new use cases, prefer Schedules. `CronSchedule` remains available for backwards compatibility.
 
 ## Getting started
 
-Create a schedule from the CLI:
-
 ```bash
 cadence schedule create \
-  --schedule_id daily-report \
-  --cron "0 9 * * *" \
-  --workflow_type GenerateDailyReport \
-  --tasklist report-workers \
-  --execution_timeout 3600
+  --schedule_id daily-etl \
+  --cron "0 2 * * *" \
+  --workflow_type RunETL \
+  --tasklist etl-workers \
+  --execution_timeout 7200
 ```
 
-SDK support for Go, Java, and Python is on the way. For now, the full API surface is available through the CLI and directly via the Cadence frontend API.
+The full API surface is available through the CLI. SDK support for Go, Java, and Python is on the way -- each will get its own guide as it ships.
 
-See the [Schedules concept page](/docs/concepts/schedules) for the full reference.
+See the [Schedules concept page](/docs/concepts/schedules) for the full reference including overlap policy details, jitter, and CLI commands.

--- a/blog/2026-06-23-cadence-schedules.md
+++ b/blog/2026-06-23-cadence-schedules.md
@@ -32,7 +32,7 @@ A Schedule is a first-class server-side object that manages recurring workflow e
 
 Your target workflow does not need to know it is being scheduled. It is a plain workflow. The scheduler handles the timing, overlap logic, and observability.
 
-This is a meaningful shift from `CronSchedule`. With `CronSchedule`, the schedule is baked into the workflow at start time -- opaque to the server, invisible to operators, impossible to modify without a restart. A Schedule is something you can observe, pause, update, and backfill without touching workflow code.
+With `CronSchedule`, the schedule is baked into the workflow at start time -- opaque to the server, invisible to operators, impossible to modify without a restart. A Schedule lives on the server. You can observe it, pause it, update it, and backfill it without touching workflow code.
 
 ## Overlap policies
 
@@ -145,6 +145,6 @@ cadence schedule create \
   --execution_timeout 7200
 ```
 
-The full API surface is available through the CLI. SDK support for Go, Java, and Python is on the way -- each will get its own guide as it ships.
+The full API surface is available through the CLI. Go, Java, and Python SDK guides are coming as each client ships support.
 
 See the [Schedules concept page](/docs/concepts/schedules) for the full reference including overlap policy details, jitter, and CLI commands.

--- a/blog/2026-06-23-cadence-schedules.md
+++ b/blog/2026-06-23-cadence-schedules.md
@@ -139,7 +139,7 @@ For new use cases, prefer Schedules. `CronSchedule` remains available for backwa
 ```bash
 cadence schedule create \
   --schedule_id daily-etl \
-  --cron "0 2 * * *" \
+  --cron_expression "0 2 * * *" \
   --workflow_type RunETL \
   --tasklist etl-workers \
   --execution_timeout 7200

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -168,3 +168,13 @@ timl3136:
     linkedin: https://www.linkedin.com/in/timl3136
     github: timl3136
 
+abhishekj720:
+  name: Abhishek Jha
+  title: Software Engineer @ Uber
+  url: https://www.linkedin.com/in/mrjhaabhishek/
+  image_url: https://github.com/abhishekj720.png
+  page: true
+  socials:
+    linkedin: https://www.linkedin.com/in/mrjhaabhishek/
+    github: abhishekj720
+

--- a/docs/03-concepts/16-schedules.md
+++ b/docs/03-concepts/16-schedules.md
@@ -215,6 +215,6 @@ cadence schedule delete --schedule_id my-schedule
 
 ## SDK usage
 
-- [Go SDK](/docs/go-client/schedules) -- `ScheduleClient` with full Create, Describe, Update, Pause, Unpause, Backfill, and List support.
+- Go SDK -- `ScheduleClient` with full Create, Describe, Update, Pause, Unpause, Backfill, and List support. See the Schedules page under Go Client in the sidebar.
 - Python SDK -- see the [cadence-python-client repository](https://github.com/cadence-workflow/cadence-python-client) for `create_schedule`, `describe_schedule`, `pause_schedule`, `unpause_schedule`, `update_schedule`, `backfill_schedule`, and `list_schedules` on the client. A dedicated docs page is coming.
 - Java SDK -- coming soon.

--- a/docs/03-concepts/16-schedules.md
+++ b/docs/03-concepts/16-schedules.md
@@ -104,7 +104,15 @@ Both Schedules and the legacy `CronSchedule` field run a workflow on a recurring
 | History and observability | Yes, last N runs visible via describe | No |
 | Update without restart | Yes | No |
 
-For new use cases, prefer Schedules. `CronSchedule` remains available for backwards compatibility.
+### Which one to use
+
+The key question is whether each scheduled time window matters independently.
+
+**Use Schedules** when every execution has its own semantic meaning. A data pipeline that processes the previous hour's events is a good example: if three runs are missed during an outage, you need to backfill and process each of those three specific time windows. Missing one means missing that window's data permanently.
+
+**Use `CronSchedule`** when only the most recent execution matters. Syncing a restaurant's current hours or menu is a good example: if three syncs are missed, running once now gives you the current state. There is nothing useful to backfill; the past windows have no independent value.
+
+`CronSchedule` remains available for backwards compatibility and for simple set-and-forget jobs where the historical record of runs is irrelevant.
 
 ## Observability
 

--- a/docs/03-concepts/16-schedules.md
+++ b/docs/03-concepts/16-schedules.md
@@ -67,9 +67,15 @@ The overlap policy can be changed on a live schedule via `UpdateSchedule`. The c
 
 ### Pause and unpause
 
-A schedule can be paused with an optional human-readable note, useful for referencing an incident ticket or change-freeze period. While paused, no new fires are dispatched. Unpausing resumes from the current time.
+A schedule can be paused with an optional human-readable note, useful for referencing an incident ticket or change-freeze period. While paused, no new fires are dispatched.
 
-Missed fires during a pause window are not replayed automatically. Use [backfill](#backfill) if you need them.
+When unpausing, you can control catch-up behavior with `--catch_up_policy`:
+
+| Policy | Behavior |
+|---|---|
+| `Skip` (default) | Resume from now; all missed fires are dropped. |
+| `One` | Dispatch at most one missed fire, then resume from now. |
+| `All` | Dispatch all missed fires within the catch-up window, then resume from now. |
 
 ### Catch-up window
 
@@ -85,7 +91,26 @@ Backfill lets you manually request fires for a specific time range in the past. 
 - You created a schedule today but want runs retroactively from an earlier date.
 - You are replaying historical data through your workflow.
 
-Each backfill request takes a start time, end time, and an optional backfill ID. Workflows started via backfill are tagged with search attributes so you can distinguish them from normal scheduled runs.
+Each backfill request takes a start time, end time, and an optional backfill ID. Backfill fires are subject to the configured overlap policy, so with `SkipNew` only the first backfill fire will run; use `Concurrent` or `CancelPrevious` when backfilling a large time range.
+
+### Search attributes on scheduled workflows
+
+Every workflow started by a schedule receives the following search attributes automatically:
+
+| Attribute | Type | Description |
+|---|---|---|
+| `CadenceScheduleID` | string | The schedule ID that triggered this run. |
+| `CadenceScheduleTime` | time | The scheduled fire time (not the actual start time). |
+| `CadenceScheduleIsBackfill` | bool | `true` if this run was started by a backfill request. |
+| `CadenceScheduleBackfillID` | string | The backfill ID, if one was provided. Only set when `CadenceScheduleIsBackfill` is `true`. |
+
+These attributes are queryable via the Cadence visibility API. For example, to find all backfill runs for a given schedule:
+
+```
+CadenceScheduleID = "my-schedule" AND CadenceScheduleIsBackfill = true
+```
+
+The `CadenceScheduleTime` attribute reflects the nominal fire time, not when the workflow actually started. This is useful in data pipelines where the workflow needs to know which time window it owns regardless of how late it started.
 
 ### Jitter
 
@@ -123,6 +148,15 @@ The `DescribeSchedule` API (and CLI command) returns:
 - Recent run history (last started and last completed times)
 - The next scheduled fire time
 
+## Limitations
+
+- **`Buffer` holds one pending fire.** If a fire arrives while one is already buffered, the newer fire is dropped. Use `Concurrent` if you need more than one pending run.
+- **Overlap policy changes are not retroactive.** Changing the policy on a live schedule does not affect runs that are already active or buffered. Only future fires use the new policy.
+- **Catch-up is bounded by the catch-up window.** The default window is one year. If the server is down for longer than the configured window, fires older than the window are silently dropped with no way to recover them automatically. Use backfill to recover those manually.
+- **Backfill fires respect the overlap policy.** Backfilling a large range with `SkipNew` will run only one workflow. Use `Concurrent` or set `--overlap_policy` on the backfill command when you need all fires to run.
+- **Jitter is not reproducible.** The random offset applied to each fire is not seeded from the schedule state. If the scheduler workflow restarts, a fire may get a different jitter offset than it would have had otherwise.
+- **The scheduler workflow counts against domain limits.** Each schedule consumes one workflow execution slot in the domain. In domains with very tight workflow count limits this is worth accounting for.
+
 ## CLI quick reference
 
 ```bash
@@ -147,10 +181,16 @@ cadence schedule create \
 # Describe
 cadence schedule describe --schedule_id my-schedule
 
+# List all schedules in the domain
+cadence schedule list
+
 # Pause
 cadence schedule pause --schedule_id my-schedule --reason "planned maintenance"
 
-# Unpause
+# Unpause (catch up on all missed fires)
+cadence schedule unpause --schedule_id my-schedule --catch_up_policy all
+
+# Unpause (skip missed fires, resume from now)
 cadence schedule unpause --schedule_id my-schedule
 
 # Backfill

--- a/docs/03-concepts/16-schedules.md
+++ b/docs/03-concepts/16-schedules.md
@@ -215,4 +215,6 @@ cadence schedule delete --schedule_id my-schedule
 
 ## SDK usage
 
-Go, Java, and Python SDK guides will be added here as each client ships support.
+- [Go SDK](/docs/go-client/schedules) -- `ScheduleClient` with full Create, Describe, Update, Pause, Unpause, Backfill, and List support.
+- Python SDK -- see the [cadence-python-client repository](https://github.com/cadence-workflow/cadence-python-client) for `create_schedule`, `describe_schedule`, `pause_schedule`, `unpause_schedule`, `update_schedule`, `backfill_schedule`, and `list_schedules` on the client. A dedicated docs page is coming.
+- Java SDK -- coming soon.

--- a/docs/03-concepts/16-schedules.md
+++ b/docs/03-concepts/16-schedules.md
@@ -1,0 +1,154 @@
+---
+layout: default
+title: Schedules
+description: Cadence Schedules let you run workflows on a recurring cadence — with overlap policies, backfill, pause/unpause, and catch-up — without writing any scheduling glue code in your workflow.
+keywords:
+  - cadence schedules
+  - cadence schedule workflow
+  - cadence recurring workflow
+  - cadence cron alternative
+  - cadence overlap policy
+  - cadence backfill
+  - cadence pause schedule
+  - cadence schedule catch-up
+  - cadence scheduler
+  - workflow scheduling
+permalink: /docs/concepts/schedules
+---
+
+# Schedules
+
+Cadence Schedules let you run a workflow on a recurring cadence. Unlike the older `CronSchedule` option on `StartWorkflowOptions`, Schedules are first-class server-side objects: you can inspect them, pause them, update them, backfill missed runs, and observe their history — all without touching your workflow code.
+
+## How it works
+
+When you create a schedule, the Cadence server runs an internal **scheduler workflow** in the background. On each tick it checks the cron expression, decides whether to fire, applies the overlap policy, and starts your target workflow. The scheduler workflow is durable — it survives server restarts and failures just like any other workflow.
+
+Your target workflow does not need to know it is being run by a schedule. It is a plain workflow started with normal arguments.
+
+## Key concepts
+
+### Schedule ID
+
+Each schedule has a unique string ID within a domain. This ID is how you reference the schedule for updates, pause/unpause, backfill, describe, and delete operations.
+
+### Cron expression
+
+Schedules use standard five-field cron syntax (`minute hour day-of-month month day-of-week`). All times are UTC.
+
+```
+# Every day at 9:00 AM UTC
+0 9 * * *
+
+# Every 15 minutes
+*/15 * * * *
+
+# Weekdays at 6:00 PM UTC
+0 18 * * 1-5
+```
+
+### Overlap policy
+
+The overlap policy controls what happens when a scheduled fire arrives while the previous run is still executing. The available policies are:
+
+| Policy | Behavior |
+|---|---|
+| `SKIP_NEW` (default) | Skip the new fire; the current run continues uninterrupted. |
+| `BUFFER_ONE` | Buffer one pending fire. Once the current run completes, the buffered fire starts immediately. |
+| `CANCEL_PREVIOUS` | Request cancellation of the current run, then start the new one. |
+| `TERMINATE_PREVIOUS` | Terminate the current run immediately, then start the new one. |
+| `ALLOW_ALL` | Start every fire unconditionally, regardless of how many runs are active. |
+
+The overlap policy can be changed on a live schedule via `UpdateSchedule`. Changing the policy is not retroactive: in-flight runs continue under the policy that was active when they started.
+
+### Pause and unpause
+
+A schedule can be paused with an optional human-readable note (e.g., the reason or ticket number). While paused, no new fires are dispatched. Unpausing resumes the schedule from the current time — it does not replay missed fires by default.
+
+Unpausing with `ALLOW_ALL` overlap policy will attempt to catch up on fires that occurred while the schedule was paused, up to a configurable window.
+
+### Catch-up window
+
+If the Cadence server is down or the scheduler workflow is delayed, fires may be missed. The catch-up window (default: one year) controls how far back the scheduler looks when it restarts. Fires older than the window are dropped silently. Fires within the window are dispatched according to the overlap policy.
+
+The scheduler uses the schedule's creation time as the earliest possible catch-up point, so a brand-new schedule that was immediately paused and then unpaused will not dispatch ancient phantom fires.
+
+### Backfill
+
+Backfill lets you manually request fires for a specific time range in the past. This is useful when:
+
+- A schedule was paused during an outage and you need to process the missed period.
+- You created a schedule today but want runs retroactively from last week.
+- You are replaying historical data through your workflow.
+
+Each backfill request takes a start time, end time, and an optional backfill ID. Fired workflows are tagged with a search attribute so you can distinguish backfill runs from normal scheduled runs.
+
+### Jitter
+
+An optional jitter (in seconds) adds a random delay to each fire, up to the specified maximum. This is useful for spreading load when many schedules are configured to fire at the same wall-clock time (e.g., midnight).
+
+## Schedules vs. distributed cron
+
+Both Schedules and the legacy `CronSchedule` field run a workflow on a recurring cadence, but they differ significantly:
+
+| | Schedules | Distributed Cron (`CronSchedule`) |
+|---|---|---|
+| Server-side object | Yes — inspect, update, delete via API | No — embedded in workflow options at start |
+| Overlap policy | Configurable per schedule | Fixed: always skip if previous run is active |
+| Pause/unpause | Yes, with notes | No |
+| Backfill | Yes | No |
+| History/observability | Yes — last N runs visible via describe | No |
+| Update without restart | Yes | No — must cancel and restart |
+
+For new use cases, prefer Schedules. Distributed cron remains available for backwards compatibility.
+
+## Observability
+
+The `DescribeSchedule` API (and CLI command) returns:
+
+- The current schedule spec (cron expression, overlap policy, jitter)
+- Whether the schedule is paused and the pause note
+- Recent run history (last started and last completed times)
+- The next scheduled fire time
+
+## CLI quick reference
+
+```bash
+# Create
+cadence schedule create \
+  --schedule_id my-schedule \
+  --cron "0 9 * * *" \
+  --workflow_type MyWorkflow \
+  --tasklist my-tasklist \
+  --execution_timeout 3600
+
+# Describe
+cadence schedule describe --schedule_id my-schedule
+
+# Pause
+cadence schedule pause --schedule_id my-schedule --reason "planned maintenance"
+
+# Unpause
+cadence schedule unpause --schedule_id my-schedule
+
+# Backfill
+cadence schedule backfill \
+  --schedule_id my-schedule \
+  --start_time "2026-06-01T00:00:00Z" \
+  --end_time   "2026-06-10T00:00:00Z" \
+  --backfill_id backfill-june-gap
+
+# Update (replace spec with a new JSON file)
+cadence schedule update --schedule_id my-schedule --schedule_file updated.json
+
+# Delete
+cadence schedule delete --schedule_id my-schedule
+```
+
+## SDK usage
+
+SDK-specific guides for creating and managing schedules in code will be added here as each client ships support:
+
+- Go SDK — coming soon
+- Java SDK — coming soon
+- Python SDK — coming soon

--- a/docs/03-concepts/16-schedules.md
+++ b/docs/03-concepts/16-schedules.md
@@ -121,7 +121,7 @@ The `DescribeSchedule` API (and CLI command) returns:
 # Create
 cadence schedule create \
   --schedule_id my-schedule \
-  --cron "0 9 * * *" \
+  --cron_expression "0 9 * * *" \
   --workflow_type MyWorkflow \
   --tasklist my-tasklist \
   --execution_timeout 3600
@@ -129,7 +129,7 @@ cadence schedule create \
 # Create with bounded concurrency (max 3 simultaneous runs)
 cadence schedule create \
   --schedule_id my-schedule \
-  --cron "*/5 * * * *" \
+  --cron_expression "*/5 * * * *" \
   --workflow_type MyWorkflow \
   --tasklist my-tasklist \
   --overlap_policy concurrent \

--- a/docs/03-concepts/16-schedules.md
+++ b/docs/03-concepts/16-schedules.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Schedules
-description: Cadence Schedules let you run workflows on a recurring cadence — with overlap policies, backfill, pause/unpause, and catch-up — without writing any scheduling glue code in your workflow.
+description: Cadence Schedules let you run workflows on a recurring cadence with overlap policies, backfill, pause/unpause, and catch-up, without writing any scheduling glue code in your workflow.
 keywords:
   - cadence schedules
   - cadence schedule workflow
@@ -22,7 +22,7 @@ Cadence Schedules let you run a workflow on a recurring cadence. Unlike the olde
 
 ## How it works
 
-When you create a schedule, the Cadence server runs an internal **scheduler workflow** in the background. On each tick it checks the cron expression, decides whether to fire, applies the overlap policy, and starts your target workflow. The scheduler workflow is durable — it survives server restarts and failures just like any other workflow.
+When you create a schedule, the Cadence server runs an internal durable scheduler workflow in the background. On each tick it evaluates the cron expression, applies the overlap policy, and starts your target workflow. The scheduler workflow is fault-tolerant — it survives server restarts and failures just like any other Cadence workflow.
 
 Your target workflow does not need to know it is being run by a schedule. It is a plain workflow started with normal arguments.
 
@@ -49,58 +49,62 @@ Schedules use standard five-field cron syntax (`minute hour day-of-month month d
 
 ### Overlap policy
 
-The overlap policy controls what happens when a scheduled fire arrives while the previous run is still executing. The available policies are:
+The overlap policy controls what happens when a scheduled fire arrives while a previous run is still executing.
 
 | Policy | Behavior |
 |---|---|
-| `SKIP_NEW` (default) | Skip the new fire; the current run continues uninterrupted. |
-| `BUFFER_ONE` | Buffer one pending fire. Once the current run completes, the buffered fire starts immediately. |
-| `CANCEL_PREVIOUS` | Request cancellation of the current run, then start the new one. |
-| `TERMINATE_PREVIOUS` | Terminate the current run immediately, then start the new one. |
-| `ALLOW_ALL` | Start every fire unconditionally, regardless of how many runs are active. |
+| `SkipNew` (default) | Skip the new fire; the current run continues uninterrupted. |
+| `Buffer` | Hold one pending fire. Once the current run finishes, the buffered fire starts immediately. |
+| `Concurrent` | Start each fire regardless of how many runs are already active. Add `--concurrency_limit N` to cap the maximum number of simultaneous runs. |
+| `CancelPrevious` | Request cancellation of the current run, then start the new one. |
+| `TerminatePrevious` | Terminate the current run immediately, then start the new one. |
 
-The overlap policy can be changed on a live schedule via `UpdateSchedule`. Changing the policy is not retroactive: in-flight runs continue under the policy that was active when they started.
+**`CancelPrevious` vs `TerminatePrevious`:** Cancellation is cooperative — the running workflow receives the signal and may continue for some time while it cleans up. Termination is immediate and unconditional. Use `TerminatePrevious` only when you need a hard guarantee that no two runs overlap even briefly.
+
+**Bounded concurrency:** `Concurrent` with `--concurrency_limit N` lets you cap how many runs are active at once — for example, "fire freely but never exceed 5 simultaneous runs." Set `--concurrency_limit 0` for unlimited.
+
+The overlap policy can be changed on a live schedule via `UpdateSchedule`. The change applies to future fires only; in-flight runs continue under the policy that was active when they started.
 
 ### Pause and unpause
 
-A schedule can be paused with an optional human-readable note (e.g., the reason or ticket number). While paused, no new fires are dispatched. Unpausing resumes the schedule from the current time — it does not replay missed fires by default.
+A schedule can be paused with an optional human-readable note — useful for referencing an incident ticket or change-freeze period. While paused, no new fires are dispatched. Unpausing resumes from the current time.
 
-Unpausing with `ALLOW_ALL` overlap policy will attempt to catch up on fires that occurred while the schedule was paused, up to a configurable window.
+Missed fires during a pause window are not replayed automatically. Use [backfill](#backfill) if you need them.
 
 ### Catch-up window
 
-If the Cadence server is down or the scheduler workflow is delayed, fires may be missed. The catch-up window (default: one year) controls how far back the scheduler looks when it restarts. Fires older than the window are dropped silently. Fires within the window are dispatched according to the overlap policy.
+If the Cadence server is unavailable and fires are missed, the scheduler catches up when it recovers — dispatching missed fires within a configurable window (default: one year). Fires older than the window are dropped silently. Fires within the window are dispatched according to the overlap policy.
 
-The scheduler uses the schedule's creation time as the earliest possible catch-up point, so a brand-new schedule that was immediately paused and then unpaused will not dispatch ancient phantom fires.
+The scheduler uses the schedule's creation time as the earliest possible catch-up point. A brand-new schedule that is immediately paused and then unpaused will not dispatch ancient phantom fires.
 
 ### Backfill
 
 Backfill lets you manually request fires for a specific time range in the past. This is useful when:
 
 - A schedule was paused during an outage and you need to process the missed period.
-- You created a schedule today but want runs retroactively from last week.
+- You created a schedule today but want runs retroactively from an earlier date.
 - You are replaying historical data through your workflow.
 
-Each backfill request takes a start time, end time, and an optional backfill ID. Fired workflows are tagged with a search attribute so you can distinguish backfill runs from normal scheduled runs.
+Each backfill request takes a start time, end time, and an optional backfill ID. Workflows started via backfill are tagged with search attributes so you can distinguish them from normal scheduled runs.
 
 ### Jitter
 
-An optional jitter (in seconds) adds a random delay to each fire, up to the specified maximum. This is useful for spreading load when many schedules are configured to fire at the same wall-clock time (e.g., midnight).
+An optional jitter (in seconds) adds a random delay to each fire, up to the specified maximum. This spreads load when many schedules fire at the same wall-clock time (for example, midnight).
 
 ## Schedules vs. distributed cron
 
 Both Schedules and the legacy `CronSchedule` field run a workflow on a recurring cadence, but they differ significantly:
 
-| | Schedules | Distributed Cron (`CronSchedule`) |
+| | Schedules | `CronSchedule` field |
 |---|---|---|
 | Server-side object | Yes — inspect, update, delete via API | No — embedded in workflow options at start |
 | Overlap policy | Configurable per schedule | Fixed: always skip if previous run is active |
 | Pause/unpause | Yes, with notes | No |
 | Backfill | Yes | No |
-| History/observability | Yes — last N runs visible via describe | No |
-| Update without restart | Yes | No — must cancel and restart |
+| History and observability | Yes — last N runs visible via describe | No |
+| Update without restart | Yes | No |
 
-For new use cases, prefer Schedules. Distributed cron remains available for backwards compatibility.
+For new use cases, prefer Schedules. `CronSchedule` remains available for backwards compatibility.
 
 ## Observability
 
@@ -122,6 +126,16 @@ cadence schedule create \
   --tasklist my-tasklist \
   --execution_timeout 3600
 
+# Create with bounded concurrency (max 3 simultaneous runs)
+cadence schedule create \
+  --schedule_id my-schedule \
+  --cron "*/5 * * * *" \
+  --workflow_type MyWorkflow \
+  --tasklist my-tasklist \
+  --overlap_policy concurrent \
+  --concurrency_limit 3 \
+  --execution_timeout 3600
+
 # Describe
 cadence schedule describe --schedule_id my-schedule
 
@@ -138,8 +152,10 @@ cadence schedule backfill \
   --end_time   "2026-06-10T00:00:00Z" \
   --backfill_id backfill-june-gap
 
-# Update (replace spec with a new JSON file)
-cadence schedule update --schedule_id my-schedule --schedule_file updated.json
+# Update overlap policy
+cadence schedule update \
+  --schedule_id my-schedule \
+  --overlap_policy skipnew
 
 # Delete
 cadence schedule delete --schedule_id my-schedule

--- a/docs/03-concepts/16-schedules.md
+++ b/docs/03-concepts/16-schedules.md
@@ -18,11 +18,11 @@ permalink: /docs/concepts/schedules
 
 # Schedules
 
-Cadence Schedules let you run a workflow on a recurring cadence. Unlike the older `CronSchedule` option on `StartWorkflowOptions`, Schedules are first-class server-side objects: you can inspect them, pause them, update them, backfill missed runs, and observe their history — all without touching your workflow code.
+Cadence Schedules let you run a workflow on a recurring cadence. Unlike the older `CronSchedule` option on `StartWorkflowOptions`, Schedules are first-class server-side objects: you can inspect them, pause them, update them, backfill missed runs, and observe their history without touching your workflow code.
 
 ## How it works
 
-When you create a schedule, the Cadence server runs an internal durable scheduler workflow in the background. On each tick it evaluates the cron expression, applies the overlap policy, and starts your target workflow. The scheduler workflow is fault-tolerant — it survives server restarts and failures just like any other Cadence workflow.
+When you create a schedule, the Cadence server runs an internal durable scheduler workflow in the background. On each tick it evaluates the cron expression, applies the overlap policy, and starts your target workflow. The scheduler workflow is fault-tolerant and survives server restarts and failures just like any other Cadence workflow.
 
 Your target workflow does not need to know it is being run by a schedule. It is a plain workflow started with normal arguments.
 
@@ -59,27 +59,27 @@ The overlap policy controls what happens when a scheduled fire arrives while a p
 | `CancelPrevious` | Request cancellation of the current run, then start the new one. |
 | `TerminatePrevious` | Terminate the current run immediately, then start the new one. |
 
-**`CancelPrevious` vs `TerminatePrevious`:** Cancellation is cooperative — the running workflow receives the signal and may continue for some time while it cleans up. Termination is immediate and unconditional. Use `TerminatePrevious` only when you need a hard guarantee that no two runs overlap even briefly.
+**`CancelPrevious` vs `TerminatePrevious`:** Cancellation is cooperative. The running workflow receives the signal and may continue for some time while it cleans up. Termination is immediate and unconditional. Use `TerminatePrevious` only when you need a hard guarantee that no two runs overlap even briefly.
 
-**Bounded concurrency:** `Concurrent` with `--concurrency_limit N` lets you cap how many runs are active at once — for example, "fire freely but never exceed 5 simultaneous runs." Set `--concurrency_limit 0` for unlimited.
+**Bounded concurrency:** `Concurrent` with `--concurrency_limit N` caps how many runs are active at once. For example, set `--concurrency_limit 5` to allow free firing but never more than 5 simultaneous runs. Set `--concurrency_limit 0` for unlimited.
 
 The overlap policy can be changed on a live schedule via `UpdateSchedule`. The change applies to future fires only; in-flight runs continue under the policy that was active when they started.
 
 ### Pause and unpause
 
-A schedule can be paused with an optional human-readable note — useful for referencing an incident ticket or change-freeze period. While paused, no new fires are dispatched. Unpausing resumes from the current time.
+A schedule can be paused with an optional human-readable note, useful for referencing an incident ticket or change-freeze period. While paused, no new fires are dispatched. Unpausing resumes from the current time.
 
 Missed fires during a pause window are not replayed automatically. Use [backfill](#backfill) if you need them.
 
 ### Catch-up window
 
-If the Cadence server is unavailable and fires are missed, the scheduler catches up when it recovers — dispatching missed fires within a configurable window (default: one year). Fires older than the window are dropped silently. Fires within the window are dispatched according to the overlap policy.
+If the Cadence server is unavailable and fires are missed, the scheduler catches up when it recovers by dispatching missed fires within a configurable window (default: one year). Fires older than the window are dropped silently. Fires within the window are dispatched according to the overlap policy.
 
 The scheduler uses the schedule's creation time as the earliest possible catch-up point. A brand-new schedule that is immediately paused and then unpaused will not dispatch ancient phantom fires.
 
 ### Backfill
 
-Backfill lets you manually request fires for a specific time range in the past. This is useful when:
+Backfill lets you manually request fires for a specific time range in the past. Common cases:
 
 - A schedule was paused during an outage and you need to process the missed period.
 - You created a schedule today but want runs retroactively from an earlier date.
@@ -97,11 +97,11 @@ Both Schedules and the legacy `CronSchedule` field run a workflow on a recurring
 
 | | Schedules | `CronSchedule` field |
 |---|---|---|
-| Server-side object | Yes — inspect, update, delete via API | No — embedded in workflow options at start |
+| Server-side object | Yes, inspect/update/delete via API | No, embedded in workflow options at start |
 | Overlap policy | Configurable per schedule | Fixed: always skip if previous run is active |
 | Pause/unpause | Yes, with notes | No |
 | Backfill | Yes | No |
-| History and observability | Yes — last N runs visible via describe | No |
+| History and observability | Yes, last N runs visible via describe | No |
 | Update without restart | Yes | No |
 
 For new use cases, prefer Schedules. `CronSchedule` remains available for backwards compatibility.
@@ -163,8 +163,4 @@ cadence schedule delete --schedule_id my-schedule
 
 ## SDK usage
 
-SDK-specific guides for creating and managing schedules in code will be added here as each client ships support:
-
-- Go SDK — coming soon
-- Java SDK — coming soon
-- Python SDK — coming soon
+Go, Java, and Python SDK guides will be added here as each client ships support.

--- a/docs/03-concepts/16-schedules.md
+++ b/docs/03-concepts/16-schedules.md
@@ -59,6 +59,8 @@ The overlap policy controls what happens when a scheduled fire arrives while a p
 | `CancelPrevious` | Request cancellation of the current run, then start the new one. |
 | `TerminatePrevious` | Terminate the current run immediately, then start the new one. |
 
+Policy values are case-insensitive when passed to the CLI (`SkipNew`, `skipnew`, and `skip_new` all work).
+
 **`CancelPrevious` vs `TerminatePrevious`:** Cancellation is cooperative. The running workflow receives the signal and may continue for some time while it cleans up. Termination is immediate and unconditional. Use `TerminatePrevious` only when you need a hard guarantee that no two runs overlap even briefly.
 
 **Bounded concurrency:** `Concurrent` with `--concurrency_limit N` caps how many runs are active at once. For example, set `--concurrency_limit 5` to allow free firing but never more than 5 simultaneous runs. Set `--concurrency_limit 0` for unlimited.
@@ -76,6 +78,8 @@ When unpausing, you can control catch-up behavior with `--catch_up_policy`:
 | `Skip` (default) | Resume from now; all missed fires are dropped. |
 | `One` | Dispatch at most one missed fire, then resume from now. |
 | `All` | Dispatch all missed fires within the catch-up window, then resume from now. |
+
+Policy values are case-insensitive when passed to the CLI.
 
 ### Catch-up window
 
@@ -174,7 +178,7 @@ cadence schedule create \
   --cron_expression "*/5 * * * *" \
   --workflow_type MyWorkflow \
   --tasklist my-tasklist \
-  --overlap_policy concurrent \
+  --overlap_policy Concurrent \
   --concurrency_limit 3 \
   --execution_timeout 3600
 
@@ -188,7 +192,7 @@ cadence schedule list
 cadence schedule pause --schedule_id my-schedule --reason "planned maintenance"
 
 # Unpause (catch up on all missed fires)
-cadence schedule unpause --schedule_id my-schedule --catch_up_policy all
+cadence schedule unpause --schedule_id my-schedule --catch_up_policy All
 
 # Unpause (skip missed fires, resume from now)
 cadence schedule unpause --schedule_id my-schedule
@@ -203,7 +207,7 @@ cadence schedule backfill \
 # Update overlap policy
 cadence schedule update \
   --schedule_id my-schedule \
-  --overlap_policy skipnew
+  --overlap_policy SkipNew
 
 # Delete
 cadence schedule delete --schedule_id my-schedule

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -66,6 +66,7 @@ const sidebars: SidebarsConfig = {
         { type: 'doc', id: 'concepts/workflow-queries-formatted-data' },
         { type: 'doc', id: 'concepts/workflow-engine' },
         { type: 'doc', id: 'concepts/open-source-workflow-engine' },
+        { type: 'doc', id: 'concepts/schedules' },
       ],
     },
     {


### PR DESCRIPTION
## What

- New concept page: `docs/concepts/schedules` covering overlap policies, backfill, pause/unpause, catch-up window, jitter, CLI quick reference, and a comparison table against `CronSchedule`
- Blog post: `2026-06-23-cadence-schedules.md` announcing the feature for practitioners
- SDK guides stubbed out on the concept page (Go/Java/Python -- filled in per-SDK as support ships)
- Added `abhishekj720` to `blog/authors.yml`

## Why

Schedules shipped on the server side but had no documentation on cadenceworkflow.io. Users have no reference for the feature beyond the CLI help text.

## Test plan

- `docusaurus build` passes cleanly on Node 22
- Sidebar entry resolves correctly (`concepts/schedules`)
- Blog post frontmatter follows the same format as existing posts
- Internal links verified (`/docs/concepts/schedules` in blog post matches the concept page permalink)