### PR TITLE
docs(go-client): add Schedules page with ScheduleClient API reference

### DIFF
--- a/docs/05-go-client/22-schedules.md
+++ b/docs/05-go-client/22-schedules.md
@@ -203,13 +203,25 @@ Deleting a schedule does not cancel or terminate any workflows it already starte
 
 ## Schedule search attributes
 
-Every workflow run triggered by a schedule is automatically tagged with the following search attributes, which you can use to filter runs via the Cadence visibility API (e.g. `ListWorkflowExecutions`):
+Cadence sets search attributes on two different workflow types. Use them to filter and query via the visibility API.
+
+### On each triggered workflow run
 
 | Attribute | Type | Value |
 |---|---|---|
-| `CadenceScheduleID` | string | The schedule ID |
-| `CadenceScheduleTime` | datetime | The nominal scheduled fire time (not actual start time) |
-| `CadenceScheduleIsBackfill` | bool | `true` if started by a backfill request |
-| `CadenceScheduleBackfillID` | string | The backfill ID, if provided |
+| `CadenceScheduleID` | Keyword | The schedule ID |
+| `CadenceScheduleTime` | Datetime | The nominal scheduled fire time (not actual start time) |
+| `CadenceScheduleIsBackfill` | Bool | `true` if started by a backfill request |
+| `CadenceScheduleBackfillID` | Keyword | The backfill ID, if provided; absent on normal fires |
 
 `CadenceScheduleTime` is the time the schedule intended to fire, not when the workflow actually started. Use it to determine which time window a triggered run should process.
+
+### On the scheduler workflow itself
+
+These are set on the internal scheduler workflow (not on triggered runs) so that `ListSchedules` can surface schedule state without querying each scheduler workflow individually.
+
+| Attribute | Type | Value |
+|---|---|---|
+| `CadenceScheduleState` | Keyword | `"active"` or `"paused"` |
+| `CadenceScheduleCron` | Keyword | The current cron expression |
+| `CadenceScheduleWorkflowType` | Keyword | The target workflow type name |

--- a/docs/05-go-client/22-schedules.md
+++ b/docs/05-go-client/22-schedules.md
@@ -1,0 +1,190 @@
+---
+layout: default
+title: Schedules
+description: How to create, manage, and backfill Cadence Schedules from Go using the ScheduleClient API.
+keywords:
+  - cadence go schedules
+  - cadence go schedule workflow
+  - cadence go recurring workflow
+  - cadence go ScheduleClient
+  - cadence go overlap policy
+  - cadence go backfill schedule
+  - cadence go pause schedule
+permalink: /docs/go-client/schedules
+---
+
+# Schedules
+
+The Go client exposes schedule management through `ScheduleClient`, obtained from any `cadence.Client` instance. For a full explanation of overlap policies, backfill, catch-up, and when to use Schedules over `CronSchedule`, see the Schedules concept page under Concepts in the sidebar.
+
+## Getting the client
+
+```go
+import (
+    "go.uber.org/cadence/client"
+    "go.uber.org/cadence/internal"
+)
+
+cadenceClient, err := client.NewClient(client.Options{...})
+if err != nil {
+    log.Fatal(err)
+}
+
+sc := cadenceClient.ScheduleClient()
+```
+
+## Creating a schedule
+
+```go
+scheduleID, err := sc.Create(ctx, &internal.CreateScheduleRequest{
+    ScheduleID: "daily-etl",
+    Spec: &internal.ScheduleSpec{
+        CronExpression: "0 2 * * *", // Every day at 2 AM UTC
+    },
+    Action: &internal.ScheduleAction{
+        StartWorkflow: &internal.ScheduleStartWorkflowAction{
+            WorkflowType:                 "RunETL",
+            TaskList:                     "etl-workers",
+            ExecutionStartToCloseTimeout: 2 * time.Hour,
+        },
+    },
+    Policies: &internal.SchedulePolicies{
+        OverlapPolicy: internal.ScheduleOverlapPolicySkipNew,
+    },
+})
+```
+
+`Create` is not idempotent. If the request succeeds on the server but you lose the response (e.g. a network timeout), call `Describe` to check whether the schedule was actually created before retrying.
+
+### Overlap policies
+
+| Constant | Behavior |
+|---|---|
+| `ScheduleOverlapPolicySkipNew` (default) | Skip the new fire if a previous run is still active. |
+| `ScheduleOverlapPolicyBuffer` | Buffer one pending fire; start it immediately when the previous run finishes. |
+| `ScheduleOverlapPolicyConcurrent` | Start every fire; use `ConcurrencyLimit` to cap simultaneous runs. |
+| `ScheduleOverlapPolicyCancelPrevious` | Cancel the active run, then start the new one. |
+| `ScheduleOverlapPolicyTerminatePrevious` | Terminate the active run immediately, then start the new one. |
+
+### Bounded concurrency
+
+```go
+Policies: &internal.SchedulePolicies{
+    OverlapPolicy:    internal.ScheduleOverlapPolicyConcurrent,
+    ConcurrencyLimit: 5, // at most 5 simultaneous runs; 0 = unlimited
+},
+```
+
+### Jitter
+
+```go
+Spec: &internal.ScheduleSpec{
+    CronExpression: "0 0 * * *",
+    Jitter:         10 * time.Minute, // random delay up to 10 minutes after midnight
+},
+```
+
+## Describing a schedule
+
+```go
+resp, err := sc.Describe(ctx, "daily-etl")
+if err != nil {
+    return err
+}
+
+fmt.Printf("Paused: %v\n", resp.State.Paused)
+fmt.Printf("Next run: %v\n", resp.Info.NextRunTime)
+fmt.Printf("Last run: %v\n", resp.Info.LastRunTime)
+```
+
+## Pause and unpause
+
+```go
+// Pause with a reason
+err = sc.Pause(ctx, "daily-etl", "INFRA-4421: cluster maintenance")
+
+// Unpause - resume from now, skip missed fires
+err = sc.Unpause(ctx, "daily-etl", "maintenance complete", internal.ScheduleCatchUpPolicySkip)
+
+// Unpause - catch up on all missed fires within the catch-up window
+err = sc.Unpause(ctx, "daily-etl", "maintenance complete", internal.ScheduleCatchUpPolicyAll)
+```
+
+Catch-up policies:
+
+| Constant | Behavior |
+|---|---|
+| `ScheduleCatchUpPolicySkip` (default) | Resume from now; all missed fires are dropped. |
+| `ScheduleCatchUpPolicyOne` | Dispatch at most one missed fire, then resume from now. |
+| `ScheduleCatchUpPolicyAll` | Dispatch all missed fires within the catch-up window. |
+
+## Updating a schedule
+
+`Update` follows a read-modify-write pattern. The SDK fetches the current state, passes it to your callback as a `*ScheduleUpdate`, and sends only the fields you mutate:
+
+```go
+err = sc.Update(ctx, "daily-etl", func(u *internal.ScheduleUpdate) error {
+    // Change the cron expression
+    u.Spec.CronExpression = "0 3 * * *" // move to 3 AM
+
+    // Change the overlap policy
+    u.Policies.OverlapPolicy = internal.ScheduleOverlapPolicyBuffer
+
+    return nil
+})
+```
+
+Changes apply to future fires only. In-flight runs are not affected.
+
+## Backfill
+
+```go
+err = sc.Backfill(ctx, "daily-etl", &internal.BackfillRequest{
+    BackfillID: "backfill-june-gap",
+    StartTime:  time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
+    EndTime:    time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC),
+})
+```
+
+Backfill fires are tagged with `CadenceScheduleIsBackfill=true` and `CadenceScheduleBackfillID` search attributes. They respect the schedule's configured overlap policy.
+
+## Listing schedules
+
+```go
+var nextPageToken []byte
+for {
+    resp, err := sc.List(ctx, 100, nextPageToken)
+    if err != nil {
+        return err
+    }
+    for _, entry := range resp.Schedules {
+        fmt.Printf("%s: paused=%v next=%v\n",
+            entry.ScheduleID, entry.State.Paused, entry.Info.NextRunTime)
+    }
+    if len(resp.NextPageToken) == 0 {
+        break
+    }
+    nextPageToken = resp.NextPageToken
+}
+```
+
+## Deleting a schedule
+
+```go
+err = sc.Delete(ctx, "daily-etl")
+```
+
+Deleting a schedule does not cancel or terminate any workflows it already started.
+
+## Reading schedule attributes from inside a workflow
+
+Every workflow started by a schedule receives search attributes automatically. These are accessible through the Cadence visibility API and can also be read at start time if needed:
+
+| Attribute | Type | Value |
+|---|---|---|
+| `CadenceScheduleID` | string | The schedule ID |
+| `CadenceScheduleTime` | time | The nominal scheduled fire time (not actual start time) |
+| `CadenceScheduleIsBackfill` | bool | `true` if started by a backfill request |
+| `CadenceScheduleBackfillID` | string | The backfill ID, if provided |
+
+The workflow itself receives no special input beyond what you configured in `ScheduleStartWorkflowAction.Input`. Use search attributes or the nominal fire time embedded in `CadenceScheduleTime` to determine which time window to process.

--- a/docs/05-go-client/22-schedules.md
+++ b/docs/05-go-client/22-schedules.md
@@ -19,16 +19,10 @@ The Go client exposes schedule management through `ScheduleClient`, obtained fro
 
 ## Getting the client
 
+`ScheduleClient` is obtained from an already-initialized `client.Client`. For the full client setup (service transport, domain, yarpc dispatcher), see the [Workers](/docs/go-client/workers) page.
+
 ```go
-import (
-    "go.uber.org/cadence/client"
-)
-
-cadenceClient, err := client.NewClient(client.Options{...})
-if err != nil {
-    log.Fatal(err)
-}
-
+// cadenceClient is a client.Client initialized for your domain
 sc := cadenceClient.ScheduleClient()
 ```
 
@@ -60,7 +54,7 @@ scheduleID, err := sc.Create(ctx, &client.CreateScheduleRequest{
 | Constant | Behavior |
 |---|---|
 | `client.ScheduleOverlapPolicySkipNew` (default) | Skip the new fire if a previous run is still active. |
-| `client.ScheduleOverlapPolicyBuffer` | Buffer one pending fire; start it immediately when the previous run finishes. |
+| `client.ScheduleOverlapPolicyBuffer` | Queue new fires and run them sequentially; depth limited by `BufferLimit`. |
 | `client.ScheduleOverlapPolicyConcurrent` | Start every fire; use `ConcurrencyLimit` to cap simultaneous runs. |
 | `client.ScheduleOverlapPolicyCancelPrevious` | Cancel the active run, then start the new one. |
 | `client.ScheduleOverlapPolicyTerminatePrevious` | Terminate the active run immediately, then start the new one. |
@@ -157,8 +151,8 @@ for {
         return err
     }
     for _, entry := range resp.Schedules {
-        fmt.Printf("%s: paused=%v next=%v\n",
-            entry.ScheduleID, entry.State.Paused, entry.Info.NextRunTime)
+        fmt.Printf("%s: paused=%v cron=%s\n",
+            entry.ScheduleID, entry.State.Paused, entry.CronExpression)
     }
     if len(resp.NextPageToken) == 0 {
         break

--- a/docs/05-go-client/22-schedules.md
+++ b/docs/05-go-client/22-schedules.md
@@ -29,7 +29,11 @@ sc := cadenceClient.ScheduleClient()
 ## Creating a schedule
 
 ```go
-import "encoding/json"
+import (
+    "encoding/json"
+    "go.uber.org/cadence"
+    "go.uber.org/cadence/client"
+)
 
 input, _ := json.Marshal(MyWorkflowInput{Date: "2026-06-01"})
 
@@ -44,6 +48,9 @@ scheduleID, err := sc.Create(ctx, &client.CreateScheduleRequest{
             TaskList:                     "etl-workers",
             Input:                        input,
             ExecutionStartToCloseTimeout: 2 * time.Hour,
+            RetryPolicy: &cadence.RetryPolicy{
+                MaximumAttempts: 3,
+            },
         },
     },
     Policies: &client.SchedulePolicies{
@@ -63,7 +70,7 @@ scheduleID, err := sc.Create(ctx, &client.CreateScheduleRequest{
 | `client.ScheduleOverlapPolicySkipNew` (default) | Skip the new fire if a previous run is still active. |
 | `client.ScheduleOverlapPolicyBuffer` | Queue new fires and run them sequentially; depth limited by `BufferLimit`. |
 | `client.ScheduleOverlapPolicyConcurrent` | Start every fire; use `ConcurrencyLimit` to cap simultaneous runs. |
-| `client.ScheduleOverlapPolicyCancelPrevious` | Cancel the active run, then start the new one. |
+| `client.ScheduleOverlapPolicyCancelPrevious` | Cancel the active run gracefully, then start the new one. |
 | `client.ScheduleOverlapPolicyTerminatePrevious` | Terminate the active run immediately, then start the new one. |
 
 ### Bounded concurrency
@@ -75,12 +82,39 @@ Policies: &client.SchedulePolicies{
 },
 ```
 
+### Buffer depth
+
+```go
+Policies: &client.SchedulePolicies{
+    OverlapPolicy: client.ScheduleOverlapPolicyBuffer,
+    BufferLimit:   10, // queue up to 10 pending fires; 0 = server default cap
+},
+```
+
+### Catch-up policy and window
+
+`CatchUpPolicy` sets the default behavior when the schedule resumes from pause. `CatchUpWindow` limits how far back the server looks for missed fires.
+
+```go
+Policies: &client.SchedulePolicies{
+    OverlapPolicy:  client.ScheduleOverlapPolicySkipNew,
+    CatchUpPolicy:  client.ScheduleCatchUpPolicyOne,
+    CatchUpWindow:  2 * time.Hour, // look back at most 2 hours for missed fires on resume
+},
+```
+
+| Constant | Behavior |
+|---|---|
+| `client.ScheduleCatchUpPolicySkip` (default) | Resume from now; all missed fires are dropped. |
+| `client.ScheduleCatchUpPolicyOne` | Dispatch at most one missed fire, then resume from now. |
+| `client.ScheduleCatchUpPolicyAll` | Dispatch all missed fires within the catch-up window. |
+
 ### Auto-pause on failure
 
 ```go
 Policies: &client.SchedulePolicies{
     OverlapPolicy:  client.ScheduleOverlapPolicySkipNew,
-    PauseOnFailure: true, // pause the schedule if a triggered run fails
+    PauseOnFailure: true,
 },
 ```
 
@@ -135,13 +169,7 @@ err = sc.Unpause(ctx, "daily-etl", "maintenance complete", client.ScheduleCatchU
 err = sc.Unpause(ctx, "daily-etl", "maintenance complete", client.ScheduleCatchUpPolicyAll)
 ```
 
-Catch-up policies:
-
-| Constant | Behavior |
-|---|---|
-| `client.ScheduleCatchUpPolicySkip` (default) | Resume from now; all missed fires are dropped. |
-| `client.ScheduleCatchUpPolicyOne` | Dispatch at most one missed fire, then resume from now. |
-| `client.ScheduleCatchUpPolicyAll` | Dispatch all missed fires within the catch-up window. |
+The catch-up policy passed to `Unpause` overrides the default set in `SchedulePolicies.CatchUpPolicy` for that single resume event.
 
 ## Updating a schedule
 
@@ -155,23 +183,27 @@ err = sc.Update(ctx, "daily-etl", func(u *client.ScheduleUpdate) error {
     // Change the overlap policy
     u.Policies.OverlapPolicy = client.ScheduleOverlapPolicyBuffer
 
+    // Change the workflow type
+    u.Action.StartWorkflow.WorkflowType = "RunETLV2"
+
     return nil
 })
 ```
 
-Changes apply to future fires only. In-flight runs are not affected.
+`ScheduleUpdate` exposes `Spec`, `Action`, and `Policies`. Mutate only the fields you want to change; the rest are left untouched. Changes apply to future fires only. In-flight runs are not affected.
 
 ## Backfill
 
 ```go
 err = sc.Backfill(ctx, "daily-etl", &client.BackfillRequest{
-    BackfillID: "backfill-june-gap",
-    StartTime:  time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
-    EndTime:    time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC),
+    BackfillID:    "backfill-june-gap",
+    StartTime:     time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
+    EndTime:       time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC),
+    OverlapPolicy: client.ScheduleOverlapPolicyConcurrent, // optional: override for this backfill only
 })
 ```
 
-Backfill fires are tagged with `CadenceScheduleIsBackfill=true` and `CadenceScheduleBackfillID` search attributes. They respect the schedule's configured overlap policy.
+`OverlapPolicy` is optional. If unset, the backfill uses the schedule's configured overlap policy. Backfill fires are tagged with `CadenceScheduleIsBackfill=true` and `CadenceScheduleBackfillID` search attributes.
 
 ## Listing schedules
 

--- a/docs/05-go-client/22-schedules.md
+++ b/docs/05-go-client/22-schedules.md
@@ -22,7 +22,6 @@ The Go client exposes schedule management through `ScheduleClient`, obtained fro
 ```go
 import (
     "go.uber.org/cadence/client"
-    "go.uber.org/cadence/internal"
 )
 
 cadenceClient, err := client.NewClient(client.Options{...})
@@ -36,20 +35,20 @@ sc := cadenceClient.ScheduleClient()
 ## Creating a schedule
 
 ```go
-scheduleID, err := sc.Create(ctx, &internal.CreateScheduleRequest{
+scheduleID, err := sc.Create(ctx, &client.CreateScheduleRequest{
     ScheduleID: "daily-etl",
-    Spec: &internal.ScheduleSpec{
+    Spec: &client.ScheduleSpec{
         CronExpression: "0 2 * * *", // Every day at 2 AM UTC
     },
-    Action: &internal.ScheduleAction{
-        StartWorkflow: &internal.ScheduleStartWorkflowAction{
+    Action: &client.ScheduleAction{
+        StartWorkflow: &client.ScheduleStartWorkflowAction{
             WorkflowType:                 "RunETL",
             TaskList:                     "etl-workers",
             ExecutionStartToCloseTimeout: 2 * time.Hour,
         },
     },
-    Policies: &internal.SchedulePolicies{
-        OverlapPolicy: internal.ScheduleOverlapPolicySkipNew,
+    Policies: &client.SchedulePolicies{
+        OverlapPolicy: client.ScheduleOverlapPolicySkipNew,
     },
 })
 ```
@@ -60,17 +59,17 @@ scheduleID, err := sc.Create(ctx, &internal.CreateScheduleRequest{
 
 | Constant | Behavior |
 |---|---|
-| `ScheduleOverlapPolicySkipNew` (default) | Skip the new fire if a previous run is still active. |
-| `ScheduleOverlapPolicyBuffer` | Buffer one pending fire; start it immediately when the previous run finishes. |
-| `ScheduleOverlapPolicyConcurrent` | Start every fire; use `ConcurrencyLimit` to cap simultaneous runs. |
-| `ScheduleOverlapPolicyCancelPrevious` | Cancel the active run, then start the new one. |
-| `ScheduleOverlapPolicyTerminatePrevious` | Terminate the active run immediately, then start the new one. |
+| `client.ScheduleOverlapPolicySkipNew` (default) | Skip the new fire if a previous run is still active. |
+| `client.ScheduleOverlapPolicyBuffer` | Buffer one pending fire; start it immediately when the previous run finishes. |
+| `client.ScheduleOverlapPolicyConcurrent` | Start every fire; use `ConcurrencyLimit` to cap simultaneous runs. |
+| `client.ScheduleOverlapPolicyCancelPrevious` | Cancel the active run, then start the new one. |
+| `client.ScheduleOverlapPolicyTerminatePrevious` | Terminate the active run immediately, then start the new one. |
 
 ### Bounded concurrency
 
 ```go
-Policies: &internal.SchedulePolicies{
-    OverlapPolicy:    internal.ScheduleOverlapPolicyConcurrent,
+Policies: &client.SchedulePolicies{
+    OverlapPolicy:    client.ScheduleOverlapPolicyConcurrent,
     ConcurrencyLimit: 5, // at most 5 simultaneous runs; 0 = unlimited
 },
 ```
@@ -78,7 +77,7 @@ Policies: &internal.SchedulePolicies{
 ### Jitter
 
 ```go
-Spec: &internal.ScheduleSpec{
+Spec: &client.ScheduleSpec{
     CronExpression: "0 0 * * *",
     Jitter:         10 * time.Minute, // random delay up to 10 minutes after midnight
 },
@@ -104,31 +103,31 @@ fmt.Printf("Last run: %v\n", resp.Info.LastRunTime)
 err = sc.Pause(ctx, "daily-etl", "INFRA-4421: cluster maintenance")
 
 // Unpause - resume from now, skip missed fires
-err = sc.Unpause(ctx, "daily-etl", "maintenance complete", internal.ScheduleCatchUpPolicySkip)
+err = sc.Unpause(ctx, "daily-etl", "maintenance complete", client.ScheduleCatchUpPolicySkip)
 
 // Unpause - catch up on all missed fires within the catch-up window
-err = sc.Unpause(ctx, "daily-etl", "maintenance complete", internal.ScheduleCatchUpPolicyAll)
+err = sc.Unpause(ctx, "daily-etl", "maintenance complete", client.ScheduleCatchUpPolicyAll)
 ```
 
 Catch-up policies:
 
 | Constant | Behavior |
 |---|---|
-| `ScheduleCatchUpPolicySkip` (default) | Resume from now; all missed fires are dropped. |
-| `ScheduleCatchUpPolicyOne` | Dispatch at most one missed fire, then resume from now. |
-| `ScheduleCatchUpPolicyAll` | Dispatch all missed fires within the catch-up window. |
+| `client.ScheduleCatchUpPolicySkip` (default) | Resume from now; all missed fires are dropped. |
+| `client.ScheduleCatchUpPolicyOne` | Dispatch at most one missed fire, then resume from now. |
+| `client.ScheduleCatchUpPolicyAll` | Dispatch all missed fires within the catch-up window. |
 
 ## Updating a schedule
 
-`Update` follows a read-modify-write pattern. The SDK fetches the current state, passes it to your callback as a `*ScheduleUpdate`, and sends only the fields you mutate:
+`Update` follows a read-modify-write pattern. The SDK fetches the current state, passes it to your callback as a `*client.ScheduleUpdate`, and sends only the fields you mutate:
 
 ```go
-err = sc.Update(ctx, "daily-etl", func(u *internal.ScheduleUpdate) error {
+err = sc.Update(ctx, "daily-etl", func(u *client.ScheduleUpdate) error {
     // Change the cron expression
     u.Spec.CronExpression = "0 3 * * *" // move to 3 AM
 
     // Change the overlap policy
-    u.Policies.OverlapPolicy = internal.ScheduleOverlapPolicyBuffer
+    u.Policies.OverlapPolicy = client.ScheduleOverlapPolicyBuffer
 
     return nil
 })
@@ -139,7 +138,7 @@ Changes apply to future fires only. In-flight runs are not affected.
 ## Backfill
 
 ```go
-err = sc.Backfill(ctx, "daily-etl", &internal.BackfillRequest{
+err = sc.Backfill(ctx, "daily-etl", &client.BackfillRequest{
     BackfillID: "backfill-june-gap",
     StartTime:  time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
     EndTime:    time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC),

--- a/docs/05-go-client/22-schedules.md
+++ b/docs/05-go-client/22-schedules.md
@@ -15,7 +15,7 @@ permalink: /docs/go-client/schedules
 
 # Schedules
 
-The Go client exposes schedule management through `ScheduleClient`, obtained from any `cadence.Client` instance. For a full explanation of overlap policies, backfill, catch-up, and when to use Schedules over `CronSchedule`, see the Schedules concept page under Concepts in the sidebar.
+The Go client exposes schedule management through `ScheduleClient`, obtained from any `cadence.Client` instance. For a full explanation of overlap policies, backfill, catch-up, and when to use Schedules over `CronSchedule`, see the [Schedules concept page](/docs/concepts/schedules).
 
 ## Getting the client
 
@@ -68,7 +68,7 @@ scheduleID, err := sc.Create(ctx, &client.CreateScheduleRequest{
 | Constant | Behavior |
 |---|---|
 | `client.ScheduleOverlapPolicySkipNew` (default) | Skip the new fire if a previous run is still active. |
-| `client.ScheduleOverlapPolicyBuffer` | Queue new fires and run them sequentially; depth limited by `BufferLimit`. |
+| `client.ScheduleOverlapPolicyBuffer` | Queue new fires and run them sequentially; depth-limited by `BufferLimit`. |
 | `client.ScheduleOverlapPolicyConcurrent` | Start every fire; use `ConcurrencyLimit` to cap simultaneous runs. |
 | `client.ScheduleOverlapPolicyCancelPrevious` | Cancel the active run gracefully, then start the new one. |
 | `client.ScheduleOverlapPolicyTerminatePrevious` | Terminate the active run immediately, then start the new one. |

--- a/docs/05-go-client/22-schedules.md
+++ b/docs/05-go-client/22-schedules.md
@@ -29,6 +29,10 @@ sc := cadenceClient.ScheduleClient()
 ## Creating a schedule
 
 ```go
+import "encoding/json"
+
+input, _ := json.Marshal(MyWorkflowInput{Date: "2026-06-01"})
+
 scheduleID, err := sc.Create(ctx, &client.CreateScheduleRequest{
     ScheduleID: "daily-etl",
     Spec: &client.ScheduleSpec{
@@ -38,6 +42,7 @@ scheduleID, err := sc.Create(ctx, &client.CreateScheduleRequest{
         StartWorkflow: &client.ScheduleStartWorkflowAction{
             WorkflowType:                 "RunETL",
             TaskList:                     "etl-workers",
+            Input:                        input,
             ExecutionStartToCloseTimeout: 2 * time.Hour,
         },
     },
@@ -46,6 +51,8 @@ scheduleID, err := sc.Create(ctx, &client.CreateScheduleRequest{
     },
 })
 ```
+
+`Input` is a pre-encoded byte slice. Encode it with `json.Marshal` for simple types, or use your configured `DataConverter` for custom types. The same bytes are passed to every triggered workflow run.
 
 `Create` is not idempotent. If the request succeeds on the server but you lose the response (e.g. a network timeout), call `Describe` to check whether the schedule was actually created before retrying.
 
@@ -68,6 +75,17 @@ Policies: &client.SchedulePolicies{
 },
 ```
 
+### Auto-pause on failure
+
+```go
+Policies: &client.SchedulePolicies{
+    OverlapPolicy:  client.ScheduleOverlapPolicySkipNew,
+    PauseOnFailure: true, // pause the schedule if a triggered run fails
+},
+```
+
+When `PauseOnFailure` is set, the schedule pauses automatically the first time a triggered workflow run fails. Unpause it with `sc.Unpause(...)` once the issue is resolved.
+
 ### Jitter
 
 ```go
@@ -76,6 +94,20 @@ Spec: &client.ScheduleSpec{
     Jitter:         10 * time.Minute, // random delay up to 10 minutes after midnight
 },
 ```
+
+### Bounded schedule window
+
+Use `StartTime` and `EndTime` to restrict when the schedule is active:
+
+```go
+Spec: &client.ScheduleSpec{
+    CronExpression: "0 9 * * 1-5", // weekdays at 9 AM
+    StartTime:      time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+    EndTime:        time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+},
+```
+
+The schedule fires only within the `[StartTime, EndTime]` window. Zero values mean no bound.
 
 ## Describing a schedule
 
@@ -169,15 +201,15 @@ err = sc.Delete(ctx, "daily-etl")
 
 Deleting a schedule does not cancel or terminate any workflows it already started.
 
-## Reading schedule attributes from inside a workflow
+## Schedule search attributes
 
-Every workflow started by a schedule receives search attributes automatically. These are accessible through the Cadence visibility API and can also be read at start time if needed:
+Every workflow run triggered by a schedule is automatically tagged with the following search attributes, which you can use to filter runs via the Cadence visibility API (e.g. `ListWorkflowExecutions`):
 
 | Attribute | Type | Value |
 |---|---|---|
 | `CadenceScheduleID` | string | The schedule ID |
-| `CadenceScheduleTime` | time | The nominal scheduled fire time (not actual start time) |
+| `CadenceScheduleTime` | datetime | The nominal scheduled fire time (not actual start time) |
 | `CadenceScheduleIsBackfill` | bool | `true` if started by a backfill request |
 | `CadenceScheduleBackfillID` | string | The backfill ID, if provided |
 
-The workflow itself receives no special input beyond what you configured in `ScheduleStartWorkflowAction.Input`. Use search attributes or the nominal fire time embedded in `CadenceScheduleTime` to determine which time window to process.
+`CadenceScheduleTime` is the time the schedule intended to fire, not when the workflow actually started. Use it to determine which time window a triggered run should process.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -124,6 +124,7 @@ const sidebars: SidebarsConfig = {
         { type: 'doc', id: 'go-client/workflow-versioning' },
         { type: 'doc', id: 'go-client/sessions' },
         { type: 'doc', id: 'go-client/distributed-cron' },
+        { type: 'doc', id: 'go-client/schedules' },
         { type: 'doc', id: 'go-client/tracing' },
         { type: 'doc', id: 'go-client/workflow-replay-shadowing' },
         { type: 'doc', id: 'go-client/workflow-non-deterministic-error' },


### PR DESCRIPTION
## What Changed
https://abhishekj720.github.io/Cadence-Docs/docs/go-client/schedules 

- Adds `docs/05-go-client/22-schedules.md`: a complete Go SDK reference for Cadence Schedules using the `ScheduleClient` API
- Covers Create, Describe, Pause/Unpause, Update (read-modify-write pattern), Backfill, List, Delete, and bounded concurrency
- Adds `go-client/schedules` entry to `sidebars.ts` under the Go Client section

## Why
Adding schedules feature to cadence

## Production Preview verification
https://abhishekj720.github.io/Cadence-Docs/docs/go-client/schedules 


## Test plan

- [x] `npm run build` passes with no broken link errors

## Potential Risks
N/A

## Documentation Notes
N/A