### PR TITLE
docs(python): add Python client section

### DIFF
--- a/docs/05-go-client/22-schedules.md
+++ b/docs/05-go-client/22-schedules.md
@@ -203,13 +203,25 @@ Deleting a schedule does not cancel or terminate any workflows it already starte
 
 ## Schedule search attributes
 
-Every workflow run triggered by a schedule is automatically tagged with the following search attributes, which you can use to filter runs via the Cadence visibility API (e.g. `ListWorkflowExecutions`):
+Cadence sets search attributes on two different workflow types. Use them to filter and query via the visibility API.
+
+### On each triggered workflow run
 
 | Attribute | Type | Value |
 |---|---|---|
-| `CadenceScheduleID` | string | The schedule ID |
-| `CadenceScheduleTime` | datetime | The nominal scheduled fire time (not actual start time) |
-| `CadenceScheduleIsBackfill` | bool | `true` if started by a backfill request |
-| `CadenceScheduleBackfillID` | string | The backfill ID, if provided |
+| `CadenceScheduleID` | Keyword | The schedule ID |
+| `CadenceScheduleTime` | Datetime | The nominal scheduled fire time (not actual start time) |
+| `CadenceScheduleIsBackfill` | Bool | `true` if started by a backfill request |
+| `CadenceScheduleBackfillID` | Keyword | The backfill ID, if provided; absent on normal fires |
 
 `CadenceScheduleTime` is the time the schedule intended to fire, not when the workflow actually started. Use it to determine which time window a triggered run should process.
+
+### On the scheduler workflow itself
+
+These are set on the internal scheduler workflow (not on triggered runs) so that `ListSchedules` can surface schedule state without querying each scheduler workflow individually.
+
+| Attribute | Type | Value |
+|---|---|---|
+| `CadenceScheduleState` | Keyword | `"active"` or `"paused"` |
+| `CadenceScheduleCron` | Keyword | The current cron expression |
+| `CadenceScheduleWorkflowType` | Keyword | The target workflow type name |

--- a/docs/05-go-client/22-schedules.md
+++ b/docs/05-go-client/22-schedules.md
@@ -1,0 +1,190 @@
+---
+layout: default
+title: Schedules
+description: How to create, manage, and backfill Cadence Schedules from Go using the ScheduleClient API.
+keywords:
+  - cadence go schedules
+  - cadence go schedule workflow
+  - cadence go recurring workflow
+  - cadence go ScheduleClient
+  - cadence go overlap policy
+  - cadence go backfill schedule
+  - cadence go pause schedule
+permalink: /docs/go-client/schedules
+---
+
+# Schedules
+
+The Go client exposes schedule management through `ScheduleClient`, obtained from any `cadence.Client` instance. For a full explanation of overlap policies, backfill, catch-up, and when to use Schedules over `CronSchedule`, see the Schedules concept page under Concepts in the sidebar.
+
+## Getting the client
+
+```go
+import (
+    "go.uber.org/cadence/client"
+    "go.uber.org/cadence/internal"
+)
+
+cadenceClient, err := client.NewClient(client.Options{...})
+if err != nil {
+    log.Fatal(err)
+}
+
+sc := cadenceClient.ScheduleClient()
+```
+
+## Creating a schedule
+
+```go
+scheduleID, err := sc.Create(ctx, &internal.CreateScheduleRequest{
+    ScheduleID: "daily-etl",
+    Spec: &internal.ScheduleSpec{
+        CronExpression: "0 2 * * *", // Every day at 2 AM UTC
+    },
+    Action: &internal.ScheduleAction{
+        StartWorkflow: &internal.ScheduleStartWorkflowAction{
+            WorkflowType:                 "RunETL",
+            TaskList:                     "etl-workers",
+            ExecutionStartToCloseTimeout: 2 * time.Hour,
+        },
+    },
+    Policies: &internal.SchedulePolicies{
+        OverlapPolicy: internal.ScheduleOverlapPolicySkipNew,
+    },
+})
+```
+
+`Create` is not idempotent. If the request succeeds on the server but you lose the response (e.g. a network timeout), call `Describe` to check whether the schedule was actually created before retrying.
+
+### Overlap policies
+
+| Constant | Behavior |
+|---|---|
+| `ScheduleOverlapPolicySkipNew` (default) | Skip the new fire if a previous run is still active. |
+| `ScheduleOverlapPolicyBuffer` | Buffer one pending fire; start it immediately when the previous run finishes. |
+| `ScheduleOverlapPolicyConcurrent` | Start every fire; use `ConcurrencyLimit` to cap simultaneous runs. |
+| `ScheduleOverlapPolicyCancelPrevious` | Cancel the active run, then start the new one. |
+| `ScheduleOverlapPolicyTerminatePrevious` | Terminate the active run immediately, then start the new one. |
+
+### Bounded concurrency
+
+```go
+Policies: &internal.SchedulePolicies{
+    OverlapPolicy:    internal.ScheduleOverlapPolicyConcurrent,
+    ConcurrencyLimit: 5, // at most 5 simultaneous runs; 0 = unlimited
+},
+```
+
+### Jitter
+
+```go
+Spec: &internal.ScheduleSpec{
+    CronExpression: "0 0 * * *",
+    Jitter:         10 * time.Minute, // random delay up to 10 minutes after midnight
+},
+```
+
+## Describing a schedule
+
+```go
+resp, err := sc.Describe(ctx, "daily-etl")
+if err != nil {
+    return err
+}
+
+fmt.Printf("Paused: %v\n", resp.State.Paused)
+fmt.Printf("Next run: %v\n", resp.Info.NextRunTime)
+fmt.Printf("Last run: %v\n", resp.Info.LastRunTime)
+```
+
+## Pause and unpause
+
+```go
+// Pause with a reason
+err = sc.Pause(ctx, "daily-etl", "INFRA-4421: cluster maintenance")
+
+// Unpause - resume from now, skip missed fires
+err = sc.Unpause(ctx, "daily-etl", "maintenance complete", internal.ScheduleCatchUpPolicySkip)
+
+// Unpause - catch up on all missed fires within the catch-up window
+err = sc.Unpause(ctx, "daily-etl", "maintenance complete", internal.ScheduleCatchUpPolicyAll)
+```
+
+Catch-up policies:
+
+| Constant | Behavior |
+|---|---|
+| `ScheduleCatchUpPolicySkip` (default) | Resume from now; all missed fires are dropped. |
+| `ScheduleCatchUpPolicyOne` | Dispatch at most one missed fire, then resume from now. |
+| `ScheduleCatchUpPolicyAll` | Dispatch all missed fires within the catch-up window. |
+
+## Updating a schedule
+
+`Update` follows a read-modify-write pattern. The SDK fetches the current state, passes it to your callback as a `*ScheduleUpdate`, and sends only the fields you mutate:
+
+```go
+err = sc.Update(ctx, "daily-etl", func(u *internal.ScheduleUpdate) error {
+    // Change the cron expression
+    u.Spec.CronExpression = "0 3 * * *" // move to 3 AM
+
+    // Change the overlap policy
+    u.Policies.OverlapPolicy = internal.ScheduleOverlapPolicyBuffer
+
+    return nil
+})
+```
+
+Changes apply to future fires only. In-flight runs are not affected.
+
+## Backfill
+
+```go
+err = sc.Backfill(ctx, "daily-etl", &internal.BackfillRequest{
+    BackfillID: "backfill-june-gap",
+    StartTime:  time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
+    EndTime:    time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC),
+})
+```
+
+Backfill fires are tagged with `CadenceScheduleIsBackfill=true` and `CadenceScheduleBackfillID` search attributes. They respect the schedule's configured overlap policy.
+
+## Listing schedules
+
+```go
+var nextPageToken []byte
+for {
+    resp, err := sc.List(ctx, 100, nextPageToken)
+    if err != nil {
+        return err
+    }
+    for _, entry := range resp.Schedules {
+        fmt.Printf("%s: paused=%v next=%v\n",
+            entry.ScheduleID, entry.State.Paused, entry.Info.NextRunTime)
+    }
+    if len(resp.NextPageToken) == 0 {
+        break
+    }
+    nextPageToken = resp.NextPageToken
+}
+```
+
+## Deleting a schedule
+
+```go
+err = sc.Delete(ctx, "daily-etl")
+```
+
+Deleting a schedule does not cancel or terminate any workflows it already started.
+
+## Reading schedule attributes from inside a workflow
+
+Every workflow started by a schedule receives search attributes automatically. These are accessible through the Cadence visibility API and can also be read at start time if needed:
+
+| Attribute | Type | Value |
+|---|---|---|
+| `CadenceScheduleID` | string | The schedule ID |
+| `CadenceScheduleTime` | time | The nominal scheduled fire time (not actual start time) |
+| `CadenceScheduleIsBackfill` | bool | `true` if started by a backfill request |
+| `CadenceScheduleBackfillID` | string | The backfill ID, if provided |
+
+The workflow itself receives no special input beyond what you configured in `ScheduleStartWorkflowAction.Input`. Use search attributes or the nominal fire time embedded in `CadenceScheduleTime` to determine which time window to process.

--- a/docs/05-go-client/22-schedules.md
+++ b/docs/05-go-client/22-schedules.md
@@ -19,16 +19,10 @@ The Go client exposes schedule management through `ScheduleClient`, obtained fro
 
 ## Getting the client
 
+`ScheduleClient` is obtained from an already-initialized `client.Client`. For the full client setup (service transport, domain, yarpc dispatcher), see the [Workers](/docs/go-client/workers) page.
+
 ```go
-import (
-    "go.uber.org/cadence/client"
-)
-
-cadenceClient, err := client.NewClient(client.Options{...})
-if err != nil {
-    log.Fatal(err)
-}
-
+// cadenceClient is a client.Client initialized for your domain
 sc := cadenceClient.ScheduleClient()
 ```
 
@@ -60,7 +54,7 @@ scheduleID, err := sc.Create(ctx, &client.CreateScheduleRequest{
 | Constant | Behavior |
 |---|---|
 | `client.ScheduleOverlapPolicySkipNew` (default) | Skip the new fire if a previous run is still active. |
-| `client.ScheduleOverlapPolicyBuffer` | Buffer one pending fire; start it immediately when the previous run finishes. |
+| `client.ScheduleOverlapPolicyBuffer` | Queue new fires and run them sequentially; depth limited by `BufferLimit`. |
 | `client.ScheduleOverlapPolicyConcurrent` | Start every fire; use `ConcurrencyLimit` to cap simultaneous runs. |
 | `client.ScheduleOverlapPolicyCancelPrevious` | Cancel the active run, then start the new one. |
 | `client.ScheduleOverlapPolicyTerminatePrevious` | Terminate the active run immediately, then start the new one. |
@@ -157,8 +151,8 @@ for {
         return err
     }
     for _, entry := range resp.Schedules {
-        fmt.Printf("%s: paused=%v next=%v\n",
-            entry.ScheduleID, entry.State.Paused, entry.Info.NextRunTime)
+        fmt.Printf("%s: paused=%v cron=%s\n",
+            entry.ScheduleID, entry.State.Paused, entry.CronExpression)
     }
     if len(resp.NextPageToken) == 0 {
         break

--- a/docs/05-go-client/22-schedules.md
+++ b/docs/05-go-client/22-schedules.md
@@ -29,7 +29,11 @@ sc := cadenceClient.ScheduleClient()
 ## Creating a schedule
 
 ```go
-import "encoding/json"
+import (
+    "encoding/json"
+    "go.uber.org/cadence"
+    "go.uber.org/cadence/client"
+)
 
 input, _ := json.Marshal(MyWorkflowInput{Date: "2026-06-01"})
 
@@ -44,6 +48,9 @@ scheduleID, err := sc.Create(ctx, &client.CreateScheduleRequest{
             TaskList:                     "etl-workers",
             Input:                        input,
             ExecutionStartToCloseTimeout: 2 * time.Hour,
+            RetryPolicy: &cadence.RetryPolicy{
+                MaximumAttempts: 3,
+            },
         },
     },
     Policies: &client.SchedulePolicies{
@@ -63,7 +70,7 @@ scheduleID, err := sc.Create(ctx, &client.CreateScheduleRequest{
 | `client.ScheduleOverlapPolicySkipNew` (default) | Skip the new fire if a previous run is still active. |
 | `client.ScheduleOverlapPolicyBuffer` | Queue new fires and run them sequentially; depth limited by `BufferLimit`. |
 | `client.ScheduleOverlapPolicyConcurrent` | Start every fire; use `ConcurrencyLimit` to cap simultaneous runs. |
-| `client.ScheduleOverlapPolicyCancelPrevious` | Cancel the active run, then start the new one. |
+| `client.ScheduleOverlapPolicyCancelPrevious` | Cancel the active run gracefully, then start the new one. |
 | `client.ScheduleOverlapPolicyTerminatePrevious` | Terminate the active run immediately, then start the new one. |
 
 ### Bounded concurrency
@@ -75,12 +82,39 @@ Policies: &client.SchedulePolicies{
 },
 ```
 
+### Buffer depth
+
+```go
+Policies: &client.SchedulePolicies{
+    OverlapPolicy: client.ScheduleOverlapPolicyBuffer,
+    BufferLimit:   10, // queue up to 10 pending fires; 0 = server default cap
+},
+```
+
+### Catch-up policy and window
+
+`CatchUpPolicy` sets the default behavior when the schedule resumes from pause. `CatchUpWindow` limits how far back the server looks for missed fires.
+
+```go
+Policies: &client.SchedulePolicies{
+    OverlapPolicy:  client.ScheduleOverlapPolicySkipNew,
+    CatchUpPolicy:  client.ScheduleCatchUpPolicyOne,
+    CatchUpWindow:  2 * time.Hour, // look back at most 2 hours for missed fires on resume
+},
+```
+
+| Constant | Behavior |
+|---|---|
+| `client.ScheduleCatchUpPolicySkip` (default) | Resume from now; all missed fires are dropped. |
+| `client.ScheduleCatchUpPolicyOne` | Dispatch at most one missed fire, then resume from now. |
+| `client.ScheduleCatchUpPolicyAll` | Dispatch all missed fires within the catch-up window. |
+
 ### Auto-pause on failure
 
 ```go
 Policies: &client.SchedulePolicies{
     OverlapPolicy:  client.ScheduleOverlapPolicySkipNew,
-    PauseOnFailure: true, // pause the schedule if a triggered run fails
+    PauseOnFailure: true,
 },
 ```
 
@@ -135,13 +169,7 @@ err = sc.Unpause(ctx, "daily-etl", "maintenance complete", client.ScheduleCatchU
 err = sc.Unpause(ctx, "daily-etl", "maintenance complete", client.ScheduleCatchUpPolicyAll)
 ```
 
-Catch-up policies:
-
-| Constant | Behavior |
-|---|---|
-| `client.ScheduleCatchUpPolicySkip` (default) | Resume from now; all missed fires are dropped. |
-| `client.ScheduleCatchUpPolicyOne` | Dispatch at most one missed fire, then resume from now. |
-| `client.ScheduleCatchUpPolicyAll` | Dispatch all missed fires within the catch-up window. |
+The catch-up policy passed to `Unpause` overrides the default set in `SchedulePolicies.CatchUpPolicy` for that single resume event.
 
 ## Updating a schedule
 
@@ -155,23 +183,27 @@ err = sc.Update(ctx, "daily-etl", func(u *client.ScheduleUpdate) error {
     // Change the overlap policy
     u.Policies.OverlapPolicy = client.ScheduleOverlapPolicyBuffer
 
+    // Change the workflow type
+    u.Action.StartWorkflow.WorkflowType = "RunETLV2"
+
     return nil
 })
 ```
 
-Changes apply to future fires only. In-flight runs are not affected.
+`ScheduleUpdate` exposes `Spec`, `Action`, and `Policies`. Mutate only the fields you want to change; the rest are left untouched. Changes apply to future fires only. In-flight runs are not affected.
 
 ## Backfill
 
 ```go
 err = sc.Backfill(ctx, "daily-etl", &client.BackfillRequest{
-    BackfillID: "backfill-june-gap",
-    StartTime:  time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
-    EndTime:    time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC),
+    BackfillID:    "backfill-june-gap",
+    StartTime:     time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
+    EndTime:       time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC),
+    OverlapPolicy: client.ScheduleOverlapPolicyConcurrent, // optional: override for this backfill only
 })
 ```
 
-Backfill fires are tagged with `CadenceScheduleIsBackfill=true` and `CadenceScheduleBackfillID` search attributes. They respect the schedule's configured overlap policy.
+`OverlapPolicy` is optional. If unset, the backfill uses the schedule's configured overlap policy. Backfill fires are tagged with `CadenceScheduleIsBackfill=true` and `CadenceScheduleBackfillID` search attributes.
 
 ## Listing schedules
 

--- a/docs/05-go-client/22-schedules.md
+++ b/docs/05-go-client/22-schedules.md
@@ -22,7 +22,6 @@ The Go client exposes schedule management through `ScheduleClient`, obtained fro
 ```go
 import (
     "go.uber.org/cadence/client"
-    "go.uber.org/cadence/internal"
 )
 
 cadenceClient, err := client.NewClient(client.Options{...})
@@ -36,20 +35,20 @@ sc := cadenceClient.ScheduleClient()
 ## Creating a schedule
 
 ```go
-scheduleID, err := sc.Create(ctx, &internal.CreateScheduleRequest{
+scheduleID, err := sc.Create(ctx, &client.CreateScheduleRequest{
     ScheduleID: "daily-etl",
-    Spec: &internal.ScheduleSpec{
+    Spec: &client.ScheduleSpec{
         CronExpression: "0 2 * * *", // Every day at 2 AM UTC
     },
-    Action: &internal.ScheduleAction{
-        StartWorkflow: &internal.ScheduleStartWorkflowAction{
+    Action: &client.ScheduleAction{
+        StartWorkflow: &client.ScheduleStartWorkflowAction{
             WorkflowType:                 "RunETL",
             TaskList:                     "etl-workers",
             ExecutionStartToCloseTimeout: 2 * time.Hour,
         },
     },
-    Policies: &internal.SchedulePolicies{
-        OverlapPolicy: internal.ScheduleOverlapPolicySkipNew,
+    Policies: &client.SchedulePolicies{
+        OverlapPolicy: client.ScheduleOverlapPolicySkipNew,
     },
 })
 ```
@@ -60,17 +59,17 @@ scheduleID, err := sc.Create(ctx, &internal.CreateScheduleRequest{
 
 | Constant | Behavior |
 |---|---|
-| `ScheduleOverlapPolicySkipNew` (default) | Skip the new fire if a previous run is still active. |
-| `ScheduleOverlapPolicyBuffer` | Buffer one pending fire; start it immediately when the previous run finishes. |
-| `ScheduleOverlapPolicyConcurrent` | Start every fire; use `ConcurrencyLimit` to cap simultaneous runs. |
-| `ScheduleOverlapPolicyCancelPrevious` | Cancel the active run, then start the new one. |
-| `ScheduleOverlapPolicyTerminatePrevious` | Terminate the active run immediately, then start the new one. |
+| `client.ScheduleOverlapPolicySkipNew` (default) | Skip the new fire if a previous run is still active. |
+| `client.ScheduleOverlapPolicyBuffer` | Buffer one pending fire; start it immediately when the previous run finishes. |
+| `client.ScheduleOverlapPolicyConcurrent` | Start every fire; use `ConcurrencyLimit` to cap simultaneous runs. |
+| `client.ScheduleOverlapPolicyCancelPrevious` | Cancel the active run, then start the new one. |
+| `client.ScheduleOverlapPolicyTerminatePrevious` | Terminate the active run immediately, then start the new one. |
 
 ### Bounded concurrency
 
 ```go
-Policies: &internal.SchedulePolicies{
-    OverlapPolicy:    internal.ScheduleOverlapPolicyConcurrent,
+Policies: &client.SchedulePolicies{
+    OverlapPolicy:    client.ScheduleOverlapPolicyConcurrent,
     ConcurrencyLimit: 5, // at most 5 simultaneous runs; 0 = unlimited
 },
 ```
@@ -78,7 +77,7 @@ Policies: &internal.SchedulePolicies{
 ### Jitter
 
 ```go
-Spec: &internal.ScheduleSpec{
+Spec: &client.ScheduleSpec{
     CronExpression: "0 0 * * *",
     Jitter:         10 * time.Minute, // random delay up to 10 minutes after midnight
 },
@@ -104,31 +103,31 @@ fmt.Printf("Last run: %v\n", resp.Info.LastRunTime)
 err = sc.Pause(ctx, "daily-etl", "INFRA-4421: cluster maintenance")
 
 // Unpause - resume from now, skip missed fires
-err = sc.Unpause(ctx, "daily-etl", "maintenance complete", internal.ScheduleCatchUpPolicySkip)
+err = sc.Unpause(ctx, "daily-etl", "maintenance complete", client.ScheduleCatchUpPolicySkip)
 
 // Unpause - catch up on all missed fires within the catch-up window
-err = sc.Unpause(ctx, "daily-etl", "maintenance complete", internal.ScheduleCatchUpPolicyAll)
+err = sc.Unpause(ctx, "daily-etl", "maintenance complete", client.ScheduleCatchUpPolicyAll)
 ```
 
 Catch-up policies:
 
 | Constant | Behavior |
 |---|---|
-| `ScheduleCatchUpPolicySkip` (default) | Resume from now; all missed fires are dropped. |
-| `ScheduleCatchUpPolicyOne` | Dispatch at most one missed fire, then resume from now. |
-| `ScheduleCatchUpPolicyAll` | Dispatch all missed fires within the catch-up window. |
+| `client.ScheduleCatchUpPolicySkip` (default) | Resume from now; all missed fires are dropped. |
+| `client.ScheduleCatchUpPolicyOne` | Dispatch at most one missed fire, then resume from now. |
+| `client.ScheduleCatchUpPolicyAll` | Dispatch all missed fires within the catch-up window. |
 
 ## Updating a schedule
 
-`Update` follows a read-modify-write pattern. The SDK fetches the current state, passes it to your callback as a `*ScheduleUpdate`, and sends only the fields you mutate:
+`Update` follows a read-modify-write pattern. The SDK fetches the current state, passes it to your callback as a `*client.ScheduleUpdate`, and sends only the fields you mutate:
 
 ```go
-err = sc.Update(ctx, "daily-etl", func(u *internal.ScheduleUpdate) error {
+err = sc.Update(ctx, "daily-etl", func(u *client.ScheduleUpdate) error {
     // Change the cron expression
     u.Spec.CronExpression = "0 3 * * *" // move to 3 AM
 
     // Change the overlap policy
-    u.Policies.OverlapPolicy = internal.ScheduleOverlapPolicyBuffer
+    u.Policies.OverlapPolicy = client.ScheduleOverlapPolicyBuffer
 
     return nil
 })
@@ -139,7 +138,7 @@ Changes apply to future fires only. In-flight runs are not affected.
 ## Backfill
 
 ```go
-err = sc.Backfill(ctx, "daily-etl", &internal.BackfillRequest{
+err = sc.Backfill(ctx, "daily-etl", &client.BackfillRequest{
     BackfillID: "backfill-june-gap",
     StartTime:  time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC),
     EndTime:    time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC),

--- a/docs/05-go-client/22-schedules.md
+++ b/docs/05-go-client/22-schedules.md
@@ -15,7 +15,7 @@ permalink: /docs/go-client/schedules
 
 # Schedules
 
-The Go client exposes schedule management through `ScheduleClient`, obtained from any `cadence.Client` instance. For a full explanation of overlap policies, backfill, catch-up, and when to use Schedules over `CronSchedule`, see the Schedules concept page under Concepts in the sidebar.
+The Go client exposes schedule management through `ScheduleClient`, obtained from any `cadence.Client` instance. For a full explanation of overlap policies, backfill, catch-up, and when to use Schedules over `CronSchedule`, see the [Schedules concept page](/docs/concepts/schedules).
 
 ## Getting the client
 
@@ -68,7 +68,7 @@ scheduleID, err := sc.Create(ctx, &client.CreateScheduleRequest{
 | Constant | Behavior |
 |---|---|
 | `client.ScheduleOverlapPolicySkipNew` (default) | Skip the new fire if a previous run is still active. |
-| `client.ScheduleOverlapPolicyBuffer` | Queue new fires and run them sequentially; depth limited by `BufferLimit`. |
+| `client.ScheduleOverlapPolicyBuffer` | Queue new fires and run them sequentially; depth-limited by `BufferLimit`. |
 | `client.ScheduleOverlapPolicyConcurrent` | Start every fire; use `ConcurrencyLimit` to cap simultaneous runs. |
 | `client.ScheduleOverlapPolicyCancelPrevious` | Cancel the active run gracefully, then start the new one. |
 | `client.ScheduleOverlapPolicyTerminatePrevious` | Terminate the active run immediately, then start the new one. |

--- a/docs/05-go-client/22-schedules.md
+++ b/docs/05-go-client/22-schedules.md
@@ -29,6 +29,10 @@ sc := cadenceClient.ScheduleClient()
 ## Creating a schedule
 
 ```go
+import "encoding/json"
+
+input, _ := json.Marshal(MyWorkflowInput{Date: "2026-06-01"})
+
 scheduleID, err := sc.Create(ctx, &client.CreateScheduleRequest{
     ScheduleID: "daily-etl",
     Spec: &client.ScheduleSpec{
@@ -38,6 +42,7 @@ scheduleID, err := sc.Create(ctx, &client.CreateScheduleRequest{
         StartWorkflow: &client.ScheduleStartWorkflowAction{
             WorkflowType:                 "RunETL",
             TaskList:                     "etl-workers",
+            Input:                        input,
             ExecutionStartToCloseTimeout: 2 * time.Hour,
         },
     },
@@ -46,6 +51,8 @@ scheduleID, err := sc.Create(ctx, &client.CreateScheduleRequest{
     },
 })
 ```
+
+`Input` is a pre-encoded byte slice. Encode it with `json.Marshal` for simple types, or use your configured `DataConverter` for custom types. The same bytes are passed to every triggered workflow run.
 
 `Create` is not idempotent. If the request succeeds on the server but you lose the response (e.g. a network timeout), call `Describe` to check whether the schedule was actually created before retrying.
 
@@ -68,6 +75,17 @@ Policies: &client.SchedulePolicies{
 },
 ```
 
+### Auto-pause on failure
+
+```go
+Policies: &client.SchedulePolicies{
+    OverlapPolicy:  client.ScheduleOverlapPolicySkipNew,
+    PauseOnFailure: true, // pause the schedule if a triggered run fails
+},
+```
+
+When `PauseOnFailure` is set, the schedule pauses automatically the first time a triggered workflow run fails. Unpause it with `sc.Unpause(...)` once the issue is resolved.
+
 ### Jitter
 
 ```go
@@ -76,6 +94,20 @@ Spec: &client.ScheduleSpec{
     Jitter:         10 * time.Minute, // random delay up to 10 minutes after midnight
 },
 ```
+
+### Bounded schedule window
+
+Use `StartTime` and `EndTime` to restrict when the schedule is active:
+
+```go
+Spec: &client.ScheduleSpec{
+    CronExpression: "0 9 * * 1-5", // weekdays at 9 AM
+    StartTime:      time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+    EndTime:        time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+},
+```
+
+The schedule fires only within the `[StartTime, EndTime]` window. Zero values mean no bound.
 
 ## Describing a schedule
 
@@ -169,15 +201,15 @@ err = sc.Delete(ctx, "daily-etl")
 
 Deleting a schedule does not cancel or terminate any workflows it already started.
 
-## Reading schedule attributes from inside a workflow
+## Schedule search attributes
 
-Every workflow started by a schedule receives search attributes automatically. These are accessible through the Cadence visibility API and can also be read at start time if needed:
+Every workflow run triggered by a schedule is automatically tagged with the following search attributes, which you can use to filter runs via the Cadence visibility API (e.g. `ListWorkflowExecutions`):
 
 | Attribute | Type | Value |
 |---|---|---|
 | `CadenceScheduleID` | string | The schedule ID |
-| `CadenceScheduleTime` | time | The nominal scheduled fire time (not actual start time) |
+| `CadenceScheduleTime` | datetime | The nominal scheduled fire time (not actual start time) |
 | `CadenceScheduleIsBackfill` | bool | `true` if started by a backfill request |
 | `CadenceScheduleBackfillID` | string | The backfill ID, if provided |
 
-The workflow itself receives no special input beyond what you configured in `ScheduleStartWorkflowAction.Input`. Use search attributes or the nominal fire time embedded in `CadenceScheduleTime` to determine which time window to process.
+`CadenceScheduleTime` is the time the schedule intended to fire, not when the workflow actually started. Use it to determine which time window a triggered run should process.

--- a/docs/07-python-client/00-index.md
+++ b/docs/07-python-client/00-index.md
@@ -1,0 +1,68 @@
+---
+layout: default
+title: Python Client
+description: Overview of the Cadence Python client SDK, an async Python library for building workflows and activities.
+keywords:
+  - cadence python client
+  - cadence python sdk
+  - cadence python workflow
+  - cadence python async
+permalink: /docs/python-client
+---
+
+# Python Client
+
+The Cadence Python client is an async Python SDK for building workflows and activities, connecting to the Cadence server over gRPC.
+
+- [cadence-python-client on GitHub](https://github.com/cadence-workflow/cadence-python-client)
+- [Python SDK samples](https://github.com/cadence-workflow/cadence-samples/tree/master/python_sdk_samples)
+
+## Installation
+
+```bash
+pip install cadence-client
+```
+
+## Packages
+
+### `cadence.client`
+
+`Client` connects to the Cadence frontend, starts and signals workflows, and manages schedules.
+
+### `cadence.worker`
+
+`Worker` polls the server for workflow and activity tasks. `Registry` holds workflow and activity definitions.
+
+### `cadence.workflow`
+
+Decorators and functions for defining workflow logic: `@workflow.run`, `@workflow.signal`, `@workflow.query`, `execute_activity`, `execute_child_workflow`, `sleep`, `continue_as_new`, and more.
+
+### `cadence.activity`
+
+Decorators for defining activities: `@activity.defn`, `@activity.method`. Context functions: `activity.heartbeat()`, `activity.info()`.
+
+### `cadence.testing`
+
+`TestWorkflowEnvironment` runs workflows in-memory for unit tests without a Cadence server.
+
+## Feature coverage
+
+| Feature | Supported |
+|---|---|
+| Workers and task lists | Yes |
+| Workflow definition and registration | Yes |
+| Starting, signaling, querying, cancelling workflows | Yes |
+| Activities with retry and heartbeat | Yes |
+| Child workflows | Yes |
+| Signals (inbound and outbound) | Yes |
+| Queries | Yes |
+| Retry policies | Yes |
+| Continue-as-new | Yes |
+| Sleep and wait conditions | Yes |
+| Distributed cron | Yes |
+| Schedules | Yes |
+| In-memory workflow testing | Yes |
+| Workflow versioning (get_version) | Not yet |
+| Side effects | Not yet |
+| Activity async completion | Not yet |
+| Sessions | Not yet |

--- a/docs/07-python-client/00-index.md
+++ b/docs/07-python-client/00-index.md
@@ -10,7 +10,7 @@ keywords:
 permalink: /docs/python-client
 ---
 
-# Python Client
+# Introduction
 
 The Cadence Python client is an async Python SDK for building workflows and activities, connecting to the Cadence server over gRPC.
 

--- a/docs/07-python-client/00-index.md
+++ b/docs/07-python-client/00-index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Python Client
+title: Introduction
 description: Overview of the Cadence Python client SDK, an async Python library for building workflows and activities.
 keywords:
   - cadence python client

--- a/docs/07-python-client/00-index.md
+++ b/docs/07-python-client/00-index.md
@@ -20,7 +20,7 @@ The Cadence Python client is an async Python SDK for building workflows and acti
 ## Installation
 
 ```bash
-pip install cadence-client
+pip install cadence-python-client
 ```
 
 ## Packages

--- a/docs/07-python-client/01-workers.md
+++ b/docs/07-python-client/01-workers.md
@@ -21,7 +21,9 @@ A worker connects to the Cadence server, polls a task list for workflow and acti
 ```python
 from cadence.client import Client
 
-async with Client(domain="my-domain", target="localhost:7833") as client:
+CADENCE_TARGET = "localhost:7833"  # replace with your Cadence frontend address
+
+async with Client(domain="my-domain", target=CADENCE_TARGET) as client:
     # client is ready here
     ...
 ```
@@ -70,7 +72,7 @@ registry.register_activity(my_activity)
 ```python
 from cadence.worker import Worker
 
-async with Client(domain="my-domain", target="localhost:7833") as client:
+async with Client(domain="my-domain", target=CADENCE_TARGET) as client:
     async with Worker(client, "my-task-list", registry):
         # Worker is polling; keep alive until interrupted
         await asyncio.Event().wait()
@@ -93,6 +95,8 @@ from cadence.client import Client
 from cadence.worker import Worker, Registry
 from cadence import workflow
 
+CADENCE_TARGET = "localhost:7833"  # replace with your Cadence frontend address
+
 registry = Registry()
 
 @registry.workflow()
@@ -102,7 +106,7 @@ class GreetingWorkflow:
         return f"Hello, {name}!"
 
 async def main():
-    async with Client(domain="my-domain", target="localhost:7833") as client:
+    async with Client(domain="my-domain", target=CADENCE_TARGET) as client:
         print("Worker running, press Ctrl-C to stop")
         async with Worker(client, "my-task-list", registry):
             await asyncio.Event().wait()

--- a/docs/07-python-client/01-workers.md
+++ b/docs/07-python-client/01-workers.md
@@ -1,0 +1,115 @@
+---
+layout: default
+title: Workers
+description: How to create a Cadence client, define a registry of workflows and activities, and start a worker in Python.
+keywords:
+  - cadence python worker
+  - cadence python client setup
+  - cadence python registry
+  - cadence python task list
+permalink: /docs/python-client/workers
+---
+
+# Workers
+
+A worker connects to the Cadence server, polls a task list for workflow and activity tasks, and executes them. Three objects work together: `Client`, `Registry`, and `Worker`.
+
+## Client
+
+`Client` connects to the Cadence frontend over gRPC. It is an async context manager.
+
+```python
+from cadence.client import Client
+
+async with Client(domain="my-domain", target="localhost:7833") as client:
+    # client is ready here
+    ...
+```
+
+| Option | Description |
+|---|---|
+| `domain` | Cadence domain (required) |
+| `target` | Cadence frontend address, `host:port` (default: `localhost:7833`) |
+| `identity` | Identity string shown in workflow history (default: auto-generated) |
+| `data_converter` | Custom data converter for serializing workflow arguments |
+
+## Registry
+
+`Registry` holds workflow and activity definitions. Create one per worker process (or share one across multiple workers).
+
+```python
+from cadence.worker import Registry
+
+registry = Registry()
+```
+
+Register workflows and activities on the registry using decorators:
+
+```python
+@registry.workflow()
+class MyWorkflow:
+    @workflow.run
+    async def run(self, name: str) -> str:
+        ...
+
+@registry.activity()
+async def my_activity(input: str) -> str:
+    ...
+```
+
+You can also register definitions imperatively:
+
+```python
+registry.register_activity(my_activity)
+```
+
+## Worker
+
+`Worker` is an async context manager that polls the task list and dispatches tasks.
+
+```python
+from cadence.worker import Worker
+
+async with Client(domain="my-domain", target="localhost:7833") as client:
+    async with Worker(client, "my-task-list", registry):
+        # Worker is polling — keep alive until interrupted
+        await asyncio.Event().wait()
+```
+
+`Worker` runs two pollers internally: one for decision (workflow) tasks and one for activity tasks. Both run concurrently.
+
+### Disabling one poller
+
+```python
+Worker(client, "my-task-list", registry, disable_activity_worker=True)
+Worker(client, "my-task-list", registry, disable_workflow_worker=True)
+```
+
+## Full example
+
+```python
+import asyncio
+from cadence.client import Client
+from cadence.worker import Worker, Registry
+from cadence import workflow
+
+registry = Registry()
+
+@registry.workflow()
+class GreetingWorkflow:
+    @workflow.run
+    async def run(self, name: str) -> str:
+        return f"Hello, {name}!"
+
+async def main():
+    async with Client(domain="my-domain", target="localhost:7833") as client:
+        print("Worker running — Ctrl-C to stop")
+        async with Worker(client, "my-task-list", registry):
+            await asyncio.Event().wait()
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass
+```

--- a/docs/07-python-client/01-workers.md
+++ b/docs/07-python-client/01-workers.md
@@ -72,7 +72,7 @@ from cadence.worker import Worker
 
 async with Client(domain="my-domain", target="localhost:7833") as client:
     async with Worker(client, "my-task-list", registry):
-        # Worker is polling — keep alive until interrupted
+        # Worker is polling; keep alive until interrupted
         await asyncio.Event().wait()
 ```
 
@@ -103,7 +103,7 @@ class GreetingWorkflow:
 
 async def main():
     async with Client(domain="my-domain", target="localhost:7833") as client:
-        print("Worker running — Ctrl-C to stop")
+        print("Worker running, press Ctrl-C to stop")
         async with Worker(client, "my-task-list", registry):
             await asyncio.Event().wait()
 

--- a/docs/07-python-client/02-workflows.md
+++ b/docs/07-python-client/02-workflows.md
@@ -1,0 +1,129 @@
+---
+layout: default
+title: Workflows
+description: How to define, register, and implement workflows in the Cadence Python SDK.
+keywords:
+  - cadence python workflow
+  - cadence python workflow definition
+  - cadence python workflow.run
+  - cadence python signal handler
+  - cadence python query handler
+permalink: /docs/python-client/workflows
+---
+
+# Workflows
+
+A workflow is a class decorated with `@registry.workflow()`. The class has exactly one `@workflow.run` method that contains the workflow logic.
+
+## Defining a workflow
+
+```python
+from cadence import Registry, workflow
+
+registry = Registry()
+
+@registry.workflow()
+class OrderWorkflow:
+    @workflow.run
+    async def run(self, order_id: str) -> str:
+        # workflow logic
+        return "completed"
+```
+
+`@registry.workflow()` registers the class under its class name by default. Pass `name=` to use a different name:
+
+```python
+@registry.workflow(name="order-workflow-v2")
+class OrderWorkflow:
+    ...
+```
+
+## Signal handlers
+
+Signal handlers receive signals sent while the workflow is running. They can be sync or async.
+
+```python
+@registry.workflow()
+class ApprovalWorkflow:
+    def __init__(self):
+        self._approved = False
+
+    @workflow.run
+    async def run(self) -> bool:
+        await workflow.wait_condition(lambda: self._approved)
+        return self._approved
+
+    @workflow.signal
+    def approve(self, approved: bool) -> None:
+        self._approved = approved
+```
+
+Use `name=` to override the signal name:
+
+```python
+@workflow.signal(name="cancel-order")
+async def cancel(self) -> None:
+    ...
+```
+
+## Query handlers
+
+Query handlers answer read-only questions about workflow state. They must be synchronous and must not modify state.
+
+```python
+@registry.workflow()
+class StatusWorkflow:
+    def __init__(self):
+        self._status = "pending"
+
+    @workflow.run
+    async def run(self) -> None:
+        ...
+
+    @workflow.query
+    def get_status(self) -> str:
+        return self._status
+```
+
+## Workflow info
+
+Inside a workflow, use `workflow.WorkflowContext.get().info` to access the current workflow's metadata:
+
+```python
+from cadence.workflow import WorkflowContext
+
+ctx = WorkflowContext.get()
+print(ctx.info.workflow_id)
+print(ctx.info.workflow_run_id)
+print(ctx.info.domain)
+print(ctx.info.task_list)
+```
+
+## Initialization
+
+The `__init__` method runs before `run` and is a good place to initialize instance state that signal handlers read and write.
+
+```python
+@registry.workflow()
+class CounterWorkflow:
+    def __init__(self):
+        self._count = 0
+
+    @workflow.run
+    async def run(self) -> int:
+        await workflow.sleep(timedelta(hours=1))
+        return self._count
+
+    @workflow.signal
+    def increment(self) -> None:
+        self._count += 1
+```
+
+## Workflow constraints
+
+Workflow code must be deterministic. The same sequence of inputs must always produce the same sequence of decisions. Specifically:
+
+- Do not use `time.time()` or `datetime.now()` -- use timers via `workflow.sleep()` instead.
+- Do not use `random`, `uuid`, or other non-deterministic sources.
+- Do not make I/O calls directly -- run them as activities.
+- Do not use threading or `asyncio.create_task()` -- the workflow event loop is controlled by the worker.

--- a/docs/07-python-client/02-workflows.md
+++ b/docs/07-python-client/02-workflows.md
@@ -87,16 +87,16 @@ class StatusWorkflow:
 
 ## Workflow info
 
-Inside a workflow, use `workflow.WorkflowContext.get().info` to access the current workflow's metadata:
+Inside a workflow, use `workflow.WorkflowContext.get().info()` to access the current workflow's metadata:
 
 ```python
 from cadence.workflow import WorkflowContext
 
 ctx = WorkflowContext.get()
-print(ctx.info.workflow_id)
-print(ctx.info.workflow_run_id)
-print(ctx.info.workflow_domain)
-print(ctx.info.workflow_task_list)
+print(ctx.info().workflow_id)
+print(ctx.info().workflow_run_id)
+print(ctx.info().workflow_domain)
+print(ctx.info().workflow_task_list)
 ```
 
 ## Initialization

--- a/docs/07-python-client/02-workflows.md
+++ b/docs/07-python-client/02-workflows.md
@@ -95,8 +95,8 @@ from cadence.workflow import WorkflowContext
 ctx = WorkflowContext.get()
 print(ctx.info.workflow_id)
 print(ctx.info.workflow_run_id)
-print(ctx.info.domain)
-print(ctx.info.task_list)
+print(ctx.info.workflow_domain)
+print(ctx.info.workflow_task_list)
 ```
 
 ## Initialization
@@ -104,6 +104,8 @@ print(ctx.info.task_list)
 The `__init__` method runs before `run` and is a good place to initialize instance state that signal handlers read and write.
 
 ```python
+from datetime import timedelta
+
 @registry.workflow()
 class CounterWorkflow:
     def __init__(self):

--- a/docs/07-python-client/03-starting-workflows.md
+++ b/docs/07-python-client/03-starting-workflows.md
@@ -1,0 +1,96 @@
+---
+layout: default
+title: Starting Workflows
+description: How to start, signal, query, and cancel workflow executions from the Cadence Python client.
+keywords:
+  - cadence python start workflow
+  - cadence python signal workflow
+  - cadence python query workflow
+  - cadence python cancel workflow
+permalink: /docs/python-client/starting-workflows
+---
+
+# Starting Workflows
+
+All workflow lifecycle operations go through the `Client`.
+
+## Start a workflow
+
+```python
+from datetime import timedelta
+from cadence.client import Client
+
+async with Client(domain="my-domain", target="localhost:7833") as client:
+    execution = await client.start_workflow(
+        "OrderWorkflow",           # workflow type name
+        "order-123",               # argument passed to workflow.run
+        workflow_id="order-123",
+        task_list="order-workers",
+        execution_start_to_close_timeout=timedelta(hours=1),
+    )
+    print(execution.workflow_id, execution.run_id)
+```
+
+`start_workflow` returns a `WorkflowExecution` with `.workflow_id` and `.run_id`. If a workflow with the same ID is already running, the default policy raises an error. Use `workflow_id_reuse_policy` to control this.
+
+### Start options
+
+| Option | Description |
+|---|---|
+| `workflow_id` | Unique ID for this execution (auto-generated if omitted) |
+| `task_list` | Task list the worker polls (required) |
+| `execution_start_to_close_timeout` | Max total duration for the workflow (required) |
+| `task_start_to_close_timeout` | Max time for a single decision task (default: 10 s) |
+| `cron_schedule` | Start as a recurring cron workflow |
+| `retry_policy` | Retry policy for the workflow |
+| `memo` | Key-value metadata attached to the execution |
+| `workflow_id_reuse_policy` | Controls what happens if the workflow ID is already in use |
+
+## Signal a running workflow
+
+```python
+await client.signal_workflow(
+    "order-123",   # workflow_id
+    "",            # run_id (empty = current run)
+    "approve",     # signal name
+    True,          # signal argument
+)
+```
+
+## Query a running workflow
+
+```python
+status = await client.query_workflow(
+    "order-123",    # workflow_id
+    "",             # run_id
+    "get_status",   # query type (matches @workflow.query handler name)
+    result_type=str,
+)
+```
+
+## Cancel a workflow
+
+```python
+await client.cancel_workflow(
+    "order-123",  # workflow_id
+    "",           # run_id
+)
+```
+
+Cancellation is cooperative. The workflow receives the cancellation and may continue for some time while cleaning up.
+
+## Signal-with-start
+
+`signal_with_start_workflow` signals a workflow if it is running, or starts it and delivers the signal if it is not.
+
+```python
+execution = await client.signal_with_start_workflow(
+    "OrderWorkflow",        # workflow type
+    "approve",              # signal name
+    [True],                 # signal arguments (list)
+    "order-123",            # workflow argument
+    workflow_id="order-123",
+    task_list="order-workers",
+    execution_start_to_close_timeout=timedelta(hours=1),
+)
+```

--- a/docs/07-python-client/03-starting-workflows.md
+++ b/docs/07-python-client/03-starting-workflows.md
@@ -20,7 +20,9 @@ All workflow lifecycle operations go through the `Client`.
 from datetime import timedelta
 from cadence.client import Client
 
-async with Client(domain="my-domain", target="localhost:7833") as client:
+CADENCE_TARGET = "localhost:7833"  # replace with your Cadence frontend address
+
+async with Client(domain="my-domain", target=CADENCE_TARGET) as client:
     execution = await client.start_workflow(
         "OrderWorkflow",           # workflow type name
         "order-123",               # argument passed to workflow.run

--- a/docs/07-python-client/04-activities.md
+++ b/docs/07-python-client/04-activities.md
@@ -1,0 +1,163 @@
+---
+layout: default
+title: Activities
+description: How to define, register, and execute activities in the Cadence Python SDK, including heartbeating and retry policies.
+keywords:
+  - cadence python activity
+  - cadence python execute activity
+  - cadence python activity heartbeat
+  - cadence python activity retry
+permalink: /docs/python-client/activities
+---
+
+# Activities
+
+Activities are where non-deterministic work happens: database calls, HTTP requests, file I/O, and anything else that touches the outside world.
+
+## Defining activities
+
+Use `@activity.defn()` for standalone functions:
+
+```python
+from cadence import activity
+
+@activity.defn()
+async def fetch_order(order_id: str) -> dict:
+    # HTTP call, DB query, etc.
+    return {"id": order_id, "status": "pending"}
+
+@activity.defn()
+def send_email(to: str, subject: str) -> None:
+    # synchronous activities work too
+    ...
+```
+
+Use `name=` to give the activity an explicit name:
+
+```python
+@activity.defn(name="fetch-order-v2")
+async def fetch_order_v2(order_id: str) -> dict:
+    ...
+```
+
+### Method activities
+
+Group related activities into a class using `@activity.method()`:
+
+```python
+from cadence import activity
+
+class OrderActivities:
+    @activity.method()
+    async def fetch_order(self, order_id: str) -> dict:
+        ...
+
+    @activity.method()
+    async def update_status(self, order_id: str, status: str) -> None:
+        ...
+```
+
+Register an instance with the registry:
+
+```python
+registry.register_activities(OrderActivities())
+```
+
+## Registering activities
+
+```python
+from cadence.worker import Registry
+
+registry = Registry()
+
+# Standalone function
+registry.register_activity(fetch_order)
+
+# All methods on an instance
+registry.register_activities(OrderActivities())
+```
+
+Or use the registry decorator directly:
+
+```python
+@registry.activity()
+async def process_payment(amount: float) -> str:
+    ...
+```
+
+## Executing activities from a workflow
+
+Inside a workflow, call `execute_activity` with the activity name, expected return type, arguments, and options:
+
+```python
+from datetime import timedelta
+from cadence.workflow import execute_activity
+
+@registry.workflow()
+class OrderWorkflow:
+    @workflow.run
+    async def run(self, order_id: str) -> str:
+        order = await execute_activity(
+            "fetch_order",
+            dict,
+            order_id,
+            start_to_close_timeout=timedelta(minutes=5),
+        )
+        await execute_activity(
+            "send_email",
+            type(None),
+            order["email"],
+            "Your order is ready",
+            start_to_close_timeout=timedelta(seconds=30),
+        )
+        return "done"
+```
+
+### Activity options
+
+| Option | Description |
+|---|---|
+| `start_to_close_timeout` | Max time for one activity attempt (required if `schedule_to_close_timeout` is not set) |
+| `schedule_to_close_timeout` | Max total time including scheduling and all retries |
+| `schedule_to_start_timeout` | Max time waiting in the task list before execution starts |
+| `heartbeat_timeout` | Max time between heartbeats for long-running activities |
+| `task_list` | Override the task list for this activity |
+| `retry_policy` | Retry policy (see [Retries](/docs/python-client/retries)) |
+
+## Heartbeating
+
+Long-running activities should call `activity.heartbeat()` periodically so the server can detect failures and reschedule:
+
+```python
+from cadence import activity
+import asyncio
+
+@activity.defn()
+async def process_large_file(file_path: str) -> int:
+    rows_processed = 0
+    with open(file_path) as f:
+        for line in f:
+            process_line(line)
+            rows_processed += 1
+            if rows_processed % 1000 == 0:
+                activity.heartbeat(rows_processed)  # report progress
+            await asyncio.sleep(0)  # yield control
+    return rows_processed
+```
+
+Pass progress details to `heartbeat()` and retrieve them on restart with `activity.heartbeat_details()`.
+
+## Activity context
+
+Inside an activity, use the `activity` module to access context:
+
+```python
+@activity.defn()
+async def my_activity() -> None:
+    info = activity.info()
+    print(info.activity_id)
+    print(info.workflow_id)
+    print(info.workflow_run_id)
+    print(info.attempt)
+    print(info.heartbeat_timeout)
+```

--- a/docs/07-python-client/05-child-workflows.md
+++ b/docs/07-python-client/05-child-workflows.md
@@ -1,0 +1,106 @@
+---
+layout: default
+title: Child Workflows
+description: How to start and await child workflow executions from within a parent workflow in the Cadence Python SDK.
+keywords:
+  - cadence python child workflow
+  - cadence python execute child workflow
+  - cadence python start child workflow
+permalink: /docs/python-client/child-workflows
+---
+
+# Child Workflows
+
+A workflow can start other workflows as children. The parent can wait for the child to complete or fire-and-forget it and track it independently.
+
+## Execute and await
+
+`execute_child_workflow` starts a child workflow and waits for its result:
+
+```python
+from datetime import timedelta
+from cadence.workflow import execute_child_workflow
+
+@registry.workflow()
+class ParentWorkflow:
+    @workflow.run
+    async def run(self, order_id: str) -> str:
+        result = await execute_child_workflow(
+            "ProcessOrderWorkflow",   # child workflow type name
+            str,                      # expected return type
+            order_id,                 # argument to child
+            task_list="order-workers",
+            execution_start_to_close_timeout=timedelta(minutes=30),
+        )
+        return result
+```
+
+## Start without immediately awaiting
+
+`start_child_workflow` returns a `ChildWorkflowFuture` you can await later or signal before awaiting:
+
+```python
+from cadence.workflow import start_child_workflow
+
+@registry.workflow()
+class ParentWorkflow:
+    @workflow.run
+    async def run(self) -> None:
+        future = await start_child_workflow(
+            "ChildWorkflow",
+            str,
+            task_list="child-workers",
+            execution_start_to_close_timeout=timedelta(hours=1),
+        )
+
+        # Send a signal before awaiting
+        await future.signal("start-processing")
+
+        result = await future
+```
+
+### ChildWorkflowFuture
+
+| Method / Property | Description |
+|---|---|
+| `await future` | Wait for the child to complete and return its result |
+| `future.workflow_id` | The child's workflow ID |
+| `future.run_id` | The child's run ID |
+| `future.cancel()` | Request cancellation of the child |
+| `await future.signal(name, *args)` | Send a signal to the child |
+
+## Child workflow options
+
+| Option | Description |
+|---|---|
+| `workflow_id` | ID for the child execution (auto-generated if omitted) |
+| `task_list` | Task list for the child worker |
+| `execution_start_to_close_timeout` | Max total duration |
+| `task_start_to_close_timeout` | Max time per decision task |
+| `retry_policy` | Retry policy for the child |
+| `cron_schedule` | Run the child as a recurring cron workflow |
+| `domain` | Domain for the child (defaults to parent's domain) |
+| `parent_close_policy` | What to do with the child when the parent closes |
+| `memo` | Key-value metadata attached to the child execution |
+
+## Parent close policy
+
+`parent_close_policy` controls what happens to the child when the parent workflow closes (completes, fails, or is cancelled):
+
+```python
+from cadence.api.v1 import workflow_pb2
+
+future = await start_child_workflow(
+    "ChildWorkflow",
+    str,
+    task_list="child-workers",
+    execution_start_to_close_timeout=timedelta(hours=1),
+    parent_close_policy=workflow_pb2.PARENT_CLOSE_POLICY_ABANDON,
+)
+```
+
+| Policy | Behavior |
+|---|---|
+| `PARENT_CLOSE_POLICY_TERMINATE` (default) | Terminate the child |
+| `PARENT_CLOSE_POLICY_ABANDON` | Leave the child running |
+| `PARENT_CLOSE_POLICY_REQUEST_CANCEL` | Request cancellation of the child |

--- a/docs/07-python-client/06-signals.md
+++ b/docs/07-python-client/06-signals.md
@@ -1,0 +1,114 @@
+---
+layout: default
+title: Signals
+description: How to define signal handlers in workflows and send signals from the Cadence Python client or from within workflows.
+keywords:
+  - cadence python signal
+  - cadence python signal handler
+  - cadence python signal workflow
+  - cadence python signal external workflow
+permalink: /docs/python-client/signals
+---
+
+# Signals
+
+Signals are one-way messages sent to a running workflow. They can carry arguments and can mutate workflow state.
+
+## Defining a signal handler
+
+Add `@workflow.signal` to a method on your workflow class. The handler can be sync or async.
+
+```python
+from cadence import Registry, workflow
+from cadence.workflow import wait_condition
+
+registry = Registry()
+
+@registry.workflow()
+class ApprovalWorkflow:
+    def __init__(self):
+        self._approved: bool | None = None
+
+    @workflow.run
+    async def run(self) -> bool:
+        await wait_condition(lambda: self._approved is not None)
+        return self._approved
+
+    @workflow.signal
+    def approve(self, approved: bool) -> None:
+        self._approved = approved
+```
+
+Use `name=` to override the signal name:
+
+```python
+@workflow.signal(name="cancel-order")
+async def cancel(self) -> None:
+    self._cancelled = True
+```
+
+## Sending a signal from a client
+
+```python
+await client.signal_workflow(
+    "my-workflow-id",   # workflow_id
+    "",                 # run_id (empty = current run)
+    "approve",          # signal name
+    True,               # signal argument
+)
+```
+
+## Signal-with-start
+
+Signal a workflow or start it if it is not running:
+
+```python
+execution = await client.signal_with_start_workflow(
+    "ApprovalWorkflow",
+    "approve",           # signal name
+    [True],              # signal args (list)
+    workflow_id="approval-123",
+    task_list="approval-workers",
+    execution_start_to_close_timeout=timedelta(hours=1),
+)
+```
+
+## Signaling external workflows
+
+From inside a workflow, use `signal_external_workflow` to send a signal to a workflow in the same or a different domain:
+
+```python
+from cadence.workflow import signal_external_workflow
+
+@registry.workflow()
+class OrchestratorWorkflow:
+    @workflow.run
+    async def run(self, child_id: str) -> None:
+        # Signal another running workflow
+        await signal_external_workflow(
+            child_id,        # workflow_id
+            "start",         # signal name
+            "go",            # signal argument
+        )
+```
+
+To target a specific run or a different domain:
+
+```python
+await signal_external_workflow(
+    "other-workflow-id",
+    "cancel",
+    run_id="specific-run-id",   # defaults to empty (current run)
+    domain="other-domain",       # defaults to empty (same domain)
+)
+```
+
+## Signaling a child workflow
+
+If you have a `ChildWorkflowFuture`, signal it directly:
+
+```python
+future = await start_child_workflow("ChildWorkflow", str, ...)
+await future.signal("start-processing", payload)
+result = await future
+```

--- a/docs/07-python-client/06-signals.md
+++ b/docs/07-python-client/06-signals.md
@@ -12,7 +12,7 @@ permalink: /docs/python-client/signals
 
 # Signals
 
-Signals are one-way messages sent to a running workflow. They can carry arguments and can mutate workflow state.
+Signals are one-way messages sent to a running workflow. They can carry arguments and can mutate workflow state. For a deeper overview, see the [Signal Handling in the Cadence Python Client](https://cadenceworkflow.io/blog/2026/04/28/2026-04-28-python-client-signal/python-client-signal) blog post.
 
 ## Defining a signal handler
 

--- a/docs/07-python-client/07-queries.md
+++ b/docs/07-python-client/07-queries.md
@@ -24,9 +24,11 @@ registry = Registry()
 class OrderWorkflow:
     def __init__(self):
         self._status = "pending"
+        self._order_id = ""
 
     @workflow.run
     async def run(self, order_id: str) -> str:
+        self._order_id = order_id
         self._status = "processing"
         result = await execute_activity(...)
         self._status = "completed"

--- a/docs/07-python-client/07-queries.md
+++ b/docs/07-python-client/07-queries.md
@@ -1,0 +1,83 @@
+---
+layout: default
+title: Queries
+description: How to define query handlers in workflows and query workflow state from the Cadence Python client.
+keywords:
+  - cadence python query
+  - cadence python query workflow
+  - cadence python query handler
+permalink: /docs/python-client/queries
+---
+
+# Queries
+
+Queries let external code read the current state of a running workflow without affecting it. Query handlers must be synchronous and must not modify workflow state.
+
+## Defining a query handler
+
+```python
+from cadence import Registry, workflow
+
+registry = Registry()
+
+@registry.workflow()
+class OrderWorkflow:
+    def __init__(self):
+        self._status = "pending"
+
+    @workflow.run
+    async def run(self, order_id: str) -> str:
+        self._status = "processing"
+        result = await execute_activity(...)
+        self._status = "completed"
+        return result
+
+    @workflow.query
+    def get_status(self) -> str:
+        return self._status
+
+    @workflow.query
+    def get_order_id(self) -> str:
+        return self._order_id
+```
+
+Use `name=` to override the query name:
+
+```python
+@workflow.query(name="status")
+def get_status(self) -> str:
+    return self._status
+```
+
+## Querying from a client
+
+```python
+status = await client.query_workflow(
+    "order-123",    # workflow_id
+    "",             # run_id (empty = current run)
+    "get_status",   # query type (must match the handler name)
+    result_type=str,
+)
+print(status)  # "processing"
+```
+
+Pass arguments to parameterized query handlers:
+
+```python
+@workflow.query
+def get_item(self, item_id: str) -> dict:
+    return self._items.get(item_id)
+
+# Client side:
+item = await client.query_workflow(
+    "order-123", "", "get_item", "item-42",
+    result_type=dict,
+)
+```
+
+## Constraints
+
+- Query handlers must return a value (cannot return `None` from an intended-to-be-queried method).
+- Query handlers must be synchronous (`def`, not `async def`).
+- Query handlers must not call `execute_activity`, `execute_child_workflow`, `sleep`, or any other workflow APIs that schedule work.
+- A query on a closed (completed/failed/cancelled) workflow returns the last known state.

--- a/docs/07-python-client/07-queries.md
+++ b/docs/07-python-client/07-queries.md
@@ -17,6 +17,7 @@ Queries let external code read the current state of a running workflow without a
 
 ```python
 from cadence import Registry, workflow
+from cadence.workflow import execute_activity
 
 registry = Registry()
 

--- a/docs/07-python-client/08-retries.md
+++ b/docs/07-python-client/08-retries.md
@@ -1,0 +1,88 @@
+---
+layout: default
+title: Retries
+description: How to configure retry policies for activities and child workflows in the Cadence Python SDK.
+keywords:
+  - cadence python retry
+  - cadence python retry policy
+  - cadence python activity retry
+permalink: /docs/python-client/retries
+---
+
+# Retries
+
+Cadence retries activities and workflows automatically on failure. You control the retry behavior with a `RetryPolicy`.
+
+## RetryPolicy
+
+`RetryPolicy` is a `TypedDict` defined in `cadence.workflow`. All fields are optional.
+
+```python
+from datetime import timedelta
+from cadence.workflow import RetryPolicy
+
+policy = RetryPolicy(
+    initial_interval=timedelta(seconds=1),     # delay before first retry
+    backoff_coefficient=2.0,                   # multiply delay by this each attempt
+    maximum_interval=timedelta(minutes=5),     # cap the delay
+    maximum_attempts=5,                        # 0 = unlimited
+    non_retryable_error_reasons=["InvalidInput"],
+    expiration_interval=timedelta(hours=1),    # stop retrying after this wall-clock time
+)
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `initial_interval` | 1 s | Delay before the first retry |
+| `backoff_coefficient` | 2.0 | Multiplier applied to delay on each attempt |
+| `maximum_interval` | 100x initial | Cap on retry delay |
+| `maximum_attempts` | Unlimited | Stop after this many total attempts (0 = unlimited) |
+| `non_retryable_error_reasons` | None | Error reason strings that bypass retries entirely |
+| `expiration_interval` | None | Stop retrying after this wall-clock duration |
+
+## Applying to an activity
+
+Pass `retry_policy` in the activity options inside a workflow:
+
+```python
+from cadence.workflow import execute_activity, RetryPolicy
+
+result = await execute_activity(
+    "fetch_order",
+    dict,
+    order_id,
+    start_to_close_timeout=timedelta(minutes=5),
+    retry_policy=RetryPolicy(
+        maximum_attempts=3,
+        non_retryable_error_reasons=["OrderNotFound"],
+    ),
+)
+```
+
+## Applying to a child workflow
+
+```python
+from cadence.workflow import execute_child_workflow, RetryPolicy
+
+result = await execute_child_workflow(
+    "ProcessOrderWorkflow",
+    str,
+    order_id,
+    task_list="order-workers",
+    execution_start_to_close_timeout=timedelta(hours=1),
+    retry_policy=RetryPolicy(
+        maximum_attempts=2,
+    ),
+)
+```
+
+## Non-retryable errors
+
+Set `non_retryable_error_reasons` to a list of error reason strings. When an activity raises an exception whose string representation matches one of these reasons, the retry stops immediately and the error propagates to the workflow.
+
+```python
+retry_policy=RetryPolicy(
+    maximum_attempts=10,
+    non_retryable_error_reasons=["InvalidInput", "Unauthorized"],
+)
+```

--- a/docs/07-python-client/08-retries.md
+++ b/docs/07-python-client/08-retries.md
@@ -15,7 +15,7 @@ Cadence retries activities and workflows automatically on failure. You control t
 
 ## RetryPolicy
 
-`RetryPolicy` is a `TypedDict` defined in `cadence.workflow`. All fields are optional.
+`RetryPolicy` is a `TypedDict` defined in `cadence.workflow`. All fields are optional in the TypedDict definition, but `initial_interval` is required by the server, and at least one of `maximum_attempts` or `expiration_interval` must be non-zero.
 
 ```python
 from datetime import timedelta
@@ -25,20 +25,22 @@ policy = RetryPolicy(
     initial_interval=timedelta(seconds=1),     # delay before first retry
     backoff_coefficient=2.0,                   # multiply delay by this each attempt
     maximum_interval=timedelta(minutes=5),     # cap the delay
-    maximum_attempts=5,                        # 0 = unlimited
+    maximum_attempts=5,                        # stop after 5 total attempts
     non_retryable_error_reasons=["InvalidInput"],
-    expiration_interval=timedelta(hours=1),    # stop retrying after this wall-clock time
+    expiration_interval=timedelta(hours=1),    # stop retrying after 1 hour
 )
 ```
 
-| Field | Default | Description |
-|---|---|---|
-| `initial_interval` | 1 s | Delay before the first retry |
-| `backoff_coefficient` | 2.0 | Multiplier applied to delay on each attempt |
-| `maximum_interval` | 100x initial | Cap on retry delay |
-| `maximum_attempts` | Unlimited | Stop after this many total attempts (0 = unlimited) |
-| `non_retryable_error_reasons` | None | Error reason strings that bypass retries entirely |
-| `expiration_interval` | None | Stop retrying after this wall-clock duration |
+| Field | Description |
+|---|---|
+| `initial_interval` | Delay before the first retry. Required; must be greater than zero. |
+| `backoff_coefficient` | Multiplier applied to delay on each attempt. Must be >= 1.0. Server default when unset: 2.0. |
+| `maximum_interval` | Cap on retry delay. Must be >= `initial_interval`. If unset, no cap is applied. |
+| `maximum_attempts` | Stop after this many total attempts. 0 means unlimited; requires `expiration_interval` to be set. |
+| `non_retryable_error_reasons` | Error reason strings that bypass retries immediately. |
+| `expiration_interval` | Stop retrying after this wall-clock duration. |
+
+`initial_interval` is required. At least one of `maximum_attempts` or `expiration_interval` must be specified; the server rejects a policy where both are zero.
 
 ## Applying to an activity
 
@@ -53,6 +55,7 @@ result = await execute_activity(
     order_id,
     start_to_close_timeout=timedelta(minutes=5),
     retry_policy=RetryPolicy(
+        initial_interval=timedelta(seconds=1),
         maximum_attempts=3,
         non_retryable_error_reasons=["OrderNotFound"],
     ),
@@ -71,6 +74,7 @@ result = await execute_child_workflow(
     task_list="order-workers",
     execution_start_to_close_timeout=timedelta(hours=1),
     retry_policy=RetryPolicy(
+        initial_interval=timedelta(seconds=1),
         maximum_attempts=2,
     ),
 )
@@ -82,6 +86,7 @@ Set `non_retryable_error_reasons` to a list of error reason strings. When an act
 
 ```python
 retry_policy=RetryPolicy(
+    initial_interval=timedelta(seconds=1),
     maximum_attempts=10,
     non_retryable_error_reasons=["InvalidInput", "Unauthorized"],
 )

--- a/docs/07-python-client/09-error-handling.md
+++ b/docs/07-python-client/09-error-handling.md
@@ -1,0 +1,113 @@
+---
+layout: default
+title: Error Handling
+description: How exceptions propagate in the Cadence Python SDK across activities, child workflows, and signals.
+keywords:
+  - cadence python error handling
+  - cadence python exception
+  - cadence python activity failure
+  - cadence python workflow failure
+permalink: /docs/python-client/error-handling
+---
+
+# Error Handling
+
+The Python SDK converts server-side failures into Python exceptions that you catch with standard `try/except`.
+
+## Activity failures
+
+When an activity raises an exception (after all retries are exhausted), the workflow receives an `ActivityFailure`. Wrap the `execute_activity` call to handle it:
+
+```python
+from cadence.error import ActivityFailure
+from cadence.workflow import execute_activity
+
+@registry.workflow()
+class OrderWorkflow:
+    @workflow.run
+    async def run(self, order_id: str) -> str:
+        try:
+            result = await execute_activity(
+                "fetch_order",
+                dict,
+                order_id,
+                start_to_close_timeout=timedelta(minutes=5),
+            )
+        except ActivityFailure as e:
+            # Log and compensate
+            await execute_activity(
+                "send_alert",
+                type(None),
+                str(e),
+                start_to_close_timeout=timedelta(seconds=30),
+            )
+            return "failed"
+        return result["status"]
+```
+
+## Child workflow failures
+
+A failed child workflow raises `ChildWorkflowExecutionFailed`:
+
+```python
+from cadence.error import ChildWorkflowExecutionFailed, StartChildWorkflowExecutionFailed
+
+try:
+    result = await execute_child_workflow("ProcessWorkflow", str, ...)
+except StartChildWorkflowExecutionFailed as e:
+    # Child could not be started (e.g. duplicate workflow ID)
+    ...
+except ChildWorkflowExecutionFailed as e:
+    # Child started but failed during execution
+    ...
+```
+
+## Signal failures
+
+Sending a signal to a workflow that no longer exists raises `SignalExternalWorkflowFailed`:
+
+```python
+from cadence.error import SignalExternalWorkflowFailed
+from cadence.workflow import signal_external_workflow
+
+try:
+    await signal_external_workflow("target-wf", "my-signal")
+except SignalExternalWorkflowFailed as e:
+    # Target workflow was not found or could not receive the signal
+    ...
+```
+
+## Workflow cancellation
+
+When a workflow is cancelled, pending `await` points raise `asyncio.CancelledError`. Catch it to run cleanup:
+
+```python
+@registry.workflow()
+class LongWorkflow:
+    @workflow.run
+    async def run(self) -> None:
+        try:
+            await execute_activity("long_activity", type(None), ...)
+        except asyncio.CancelledError:
+            await execute_activity("cleanup_activity", type(None), ...)
+            raise  # re-raise so Cadence records the cancellation
+```
+
+## Error reference
+
+| Exception | When raised |
+|---|---|
+| `ActivityFailure` | Activity exhausted all retries or returned a non-retryable error |
+| `WorkflowFailure` | A workflow execution failed |
+| `StartChildWorkflowExecutionFailed` | Child workflow could not be started |
+| `ChildWorkflowExecutionFailed` | Child workflow started but failed |
+| `SignalExternalWorkflowFailed` | Signal delivery to an external workflow failed |
+| `SignalFailure` | Internal signal routing failure |
+| `ContinueAsNewError` | Raised internally by `workflow.continue_as_new()` -- do not catch |
+| `CadenceRpcError` | gRPC-level error from the Cadence server (client-side code) |
+
+Import from `cadence.error`:
+
+```python
+from cadence.error import ActivityFailure, ChildWorkflowExecutionFailed, CadenceRpcError
+```

--- a/docs/07-python-client/09-error-handling.md
+++ b/docs/07-python-client/09-error-handling.md
@@ -19,6 +19,7 @@ The Python SDK converts server-side failures into Python exceptions that you cat
 When an activity raises an exception (after all retries are exhausted), the workflow receives an `ActivityFailure`. Wrap the `execute_activity` call to handle it:
 
 ```python
+from datetime import timedelta
 from cadence.error import ActivityFailure
 from cadence.workflow import execute_activity
 

--- a/docs/07-python-client/09-error-handling.md
+++ b/docs/07-python-client/09-error-handling.md
@@ -79,7 +79,7 @@ except ChildWorkflowExecutionTerminated:
     ...
 ```
 
-All five are subclasses of `ChildWorkflowError` -- catch that base class if you want a single handler for any child workflow lifecycle error.
+All five are subclasses of `ChildWorkflowError`, so you can catch that base class if you want a single handler for any child workflow lifecycle error.
 
 ## Signal failures
 
@@ -126,7 +126,7 @@ class LongWorkflow:
 | `ChildWorkflowError` | Base class for all five child workflow lifecycle errors above |
 | `SignalExternalWorkflowFailed` | Signal delivery to an external workflow failed |
 | `SignalFailure` | Internal signal routing failure |
-| `ContinueAsNewError` | Raised internally by `workflow.continue_as_new()` -- do not catch |
+| `ContinueAsNewError` | Raised internally by `workflow.continue_as_new()`. Do not catch. |
 | `CadenceRpcError` | gRPC-level error from the Cadence server (client-side code) |
 
 Import from `cadence.error`:

--- a/docs/07-python-client/09-error-handling.md
+++ b/docs/07-python-client/09-error-handling.md
@@ -48,10 +48,16 @@ class OrderWorkflow:
 
 ## Child workflow failures
 
-A failed child workflow raises `ChildWorkflowExecutionFailed`:
+Child workflows raise different exceptions depending on how they ended:
 
 ```python
-from cadence.error import ChildWorkflowExecutionFailed, StartChildWorkflowExecutionFailed
+from cadence.error import (
+    StartChildWorkflowExecutionFailed,
+    ChildWorkflowExecutionFailed,
+    ChildWorkflowExecutionCanceled,
+    ChildWorkflowExecutionTimedOut,
+    ChildWorkflowExecutionTerminated,
+)
 
 try:
     result = await execute_child_workflow("ProcessWorkflow", str, ...)
@@ -61,7 +67,19 @@ except StartChildWorkflowExecutionFailed as e:
 except ChildWorkflowExecutionFailed as e:
     # Child started but failed during execution
     ...
+except ChildWorkflowExecutionCanceled as e:
+    # Child was cancelled (e.g. parent requested cancellation)
+    ...
+except ChildWorkflowExecutionTimedOut as e:
+    # Child exceeded its execution timeout
+    # e.timeout_type indicates which timeout fired
+    ...
+except ChildWorkflowExecutionTerminated:
+    # Child was forcibly terminated
+    ...
 ```
+
+All five are subclasses of `ChildWorkflowError` -- catch that base class if you want a single handler for any child workflow lifecycle error.
 
 ## Signal failures
 
@@ -102,6 +120,10 @@ class LongWorkflow:
 | `WorkflowFailure` | A workflow execution failed |
 | `StartChildWorkflowExecutionFailed` | Child workflow could not be started |
 | `ChildWorkflowExecutionFailed` | Child workflow started but failed |
+| `ChildWorkflowExecutionCanceled` | Child workflow was cancelled |
+| `ChildWorkflowExecutionTimedOut` | Child workflow exceeded its execution timeout |
+| `ChildWorkflowExecutionTerminated` | Child workflow was forcibly terminated |
+| `ChildWorkflowError` | Base class for all five child workflow lifecycle errors above |
 | `SignalExternalWorkflowFailed` | Signal delivery to an external workflow failed |
 | `SignalFailure` | Internal signal routing failure |
 | `ContinueAsNewError` | Raised internally by `workflow.continue_as_new()` -- do not catch |

--- a/docs/07-python-client/10-continue-as-new.md
+++ b/docs/07-python-client/10-continue-as-new.md
@@ -1,0 +1,63 @@
+---
+layout: default
+title: Continue-as-New
+description: How to use continue-as-new to reset workflow history in the Cadence Python SDK.
+keywords:
+  - cadence python continue as new
+  - cadence python workflow history
+  - cadence python continue_as_new
+permalink: /docs/python-client/continue-as-new
+---
+
+# Continue-as-New
+
+Workflow history grows unbounded as the workflow executes. When history becomes too large, use continue-as-new to restart the workflow with a fresh history while preserving its logical state.
+
+`workflow.continue_as_new` never returns -- it raises `ContinueAsNewError` internally, which the worker intercepts to schedule a new execution.
+
+## Basic usage
+
+```python
+from cadence import workflow, Registry
+
+registry = Registry()
+
+@registry.workflow()
+class ProcessorWorkflow:
+    @workflow.run
+    async def run(self, processed_count: int) -> None:
+        for _ in range(1000):
+            await execute_activity("process_item", type(None), ...)
+            processed_count += 1
+
+        # History is getting long -- restart with updated state
+        workflow.continue_as_new(processed_count)
+```
+
+The argument to `continue_as_new` is passed to the next execution's `run` method.
+
+## Overriding workflow parameters
+
+```python
+workflow.continue_as_new(
+    processed_count,
+    workflow_type="ProcessorWorkflowV2",    # switch to a different workflow type
+    task_list="new-task-list",              # move to a different task list
+    execution_start_to_close_timeout=timedelta(hours=2),
+    task_start_to_close_timeout=timedelta(minutes=1),
+)
+```
+
+All parameters are optional. Omitted parameters inherit from the current execution.
+
+## When to use continue-as-new
+
+- The workflow runs for days or weeks and accumulates many history events.
+- The workflow processes an unbounded stream of items (e.g. an event loop).
+- The workflow is a long-lived cron-style loop that does not use `CronSchedule`.
+
+Cadence imposes a server-side limit on history size. Workflows that approach the limit are automatically terminated if they do not CAN first. The Python SDK does not enforce a specific event count limit, but a general guideline is to CAN after every few thousand events or whenever you complete a logical "epoch" of processing.
+
+## Do not catch ContinueAsNewError
+
+`workflow.continue_as_new` raises `ContinueAsNewError` internally. Do not catch `ContinueAsNewError` in your workflow code -- doing so prevents the continue-as-new from taking effect.

--- a/docs/07-python-client/10-continue-as-new.md
+++ b/docs/07-python-client/10-continue-as-new.md
@@ -18,7 +18,9 @@ Workflow history grows unbounded as the workflow executes. When history becomes 
 ## Basic usage
 
 ```python
+from datetime import timedelta
 from cadence import workflow, Registry
+from cadence.workflow import execute_activity
 
 registry = Registry()
 
@@ -39,6 +41,8 @@ The argument to `continue_as_new` is passed to the next execution's `run` method
 ## Overriding workflow parameters
 
 ```python
+from datetime import timedelta
+
 workflow.continue_as_new(
     processed_count,
     workflow_type="ProcessorWorkflowV2",    # switch to a different workflow type

--- a/docs/07-python-client/11-distributed-cron.md
+++ b/docs/07-python-client/11-distributed-cron.md
@@ -19,7 +19,9 @@ The `cron_schedule` field on `start_workflow` runs a workflow on a recurring cad
 from datetime import timedelta
 from cadence.client import Client
 
-async with Client(domain="my-domain", target="localhost:7833") as client:
+CADENCE_TARGET = "localhost:7833"  # replace with your Cadence frontend address
+
+async with Client(domain="my-domain", target=CADENCE_TARGET) as client:
     execution = await client.start_workflow(
         "DailyReportWorkflow",
         workflow_id="daily-report",

--- a/docs/07-python-client/11-distributed-cron.md
+++ b/docs/07-python-client/11-distributed-cron.md
@@ -1,0 +1,77 @@
+---
+layout: default
+title: Distributed Cron
+description: How to run a recurring workflow using the cron_schedule option in the Cadence Python SDK.
+keywords:
+  - cadence python cron
+  - cadence python distributed cron
+  - cadence python recurring workflow
+permalink: /docs/python-client/distributed-cron
+---
+
+# Distributed Cron
+
+The `cron_schedule` field on `start_workflow` runs a workflow on a recurring cadence. This is the legacy approach; for new use cases consider [Schedules](/docs/python-client/schedules), which add pause/unpause, backfill, overlap control, and visibility.
+
+## Starting a cron workflow
+
+```python
+from datetime import timedelta
+from cadence.client import Client
+
+async with Client(domain="my-domain", target="localhost:7833") as client:
+    execution = await client.start_workflow(
+        "DailyReportWorkflow",
+        workflow_id="daily-report",
+        task_list="report-workers",
+        cron_schedule="0 9 * * *",   # every day at 9 AM UTC
+        execution_start_to_close_timeout=timedelta(hours=2),
+    )
+```
+
+Standard five-field cron syntax is used (`minute hour day-of-month month day-of-week`). All times are UTC.
+
+## How it works
+
+After each run completes (or fails), the Cadence server automatically starts the next execution at the next scheduled time. Each execution is independent: it gets a fresh workflow history and runs from the beginning of the workflow function.
+
+If a run is still executing when the next fire time arrives, the new fire is skipped.
+
+## Passing state between runs
+
+Each execution of the workflow function is independent. To carry state from one run to the next, use the workflow result: the next execution receives the previous run's result as its first argument.
+
+```python
+@registry.workflow()
+class DailyReportWorkflow:
+    @workflow.run
+    async def run(self, last_cursor: str | None = None) -> str:
+        # Process from where last run left off
+        new_cursor = await execute_activity(
+            "generate_report",
+            str,
+            last_cursor,
+            start_to_close_timeout=timedelta(hours=1),
+        )
+        return new_cursor  # passed to next execution
+```
+
+## Stopping a cron workflow
+
+Cancel or terminate the workflow execution. Cancelling stops the next scheduled run; no built-in mechanism pauses and resumes a cron workflow. For pause/unpause support, use [Schedules](/docs/python-client/schedules).
+
+```python
+await client.cancel_workflow("daily-report", "")
+```
+
+## Cron vs Schedules
+
+| | `cron_schedule` field | Schedules |
+|---|---|---|
+| Overlap control | Always skip | Configurable |
+| Pause/unpause | No | Yes |
+| Backfill | No | Yes |
+| Visibility | No | Yes |
+| Update without restart | No | Yes |
+
+For new recurring workflows, prefer Schedules.

--- a/docs/07-python-client/11-distributed-cron.md
+++ b/docs/07-python-client/11-distributed-cron.md
@@ -44,6 +44,13 @@ If a run is still executing when the next fire time arrives, the new fire is ski
 Each execution of the workflow function is independent. To carry state from one run to the next, use the workflow result: the next execution receives the previous run's result as its first argument.
 
 ```python
+from datetime import timedelta
+from cadence import workflow
+from cadence.worker import Registry
+from cadence.workflow import execute_activity
+
+registry = Registry()
+
 @registry.workflow()
 class DailyReportWorkflow:
     @workflow.run

--- a/docs/07-python-client/12-schedules.md
+++ b/docs/07-python-client/12-schedules.md
@@ -22,7 +22,9 @@ Schedule operations use protobuf types from `cadence.api.v1.schedule_pb2`.
 ```python
 from cadence.client import Client
 
-async with Client(domain="my-domain", target="localhost:7833") as client:
+CADENCE_TARGET = "localhost:7833"  # replace with your Cadence frontend address
+
+async with Client(domain="my-domain", target=CADENCE_TARGET) as client:
     # call client.create_schedule(...), client.describe_schedule(...), etc.
     ...
 ```

--- a/docs/07-python-client/12-schedules.md
+++ b/docs/07-python-client/12-schedules.md
@@ -1,0 +1,180 @@
+---
+layout: default
+title: Schedules
+description: How to create, manage, and backfill Cadence Schedules from Python using the schedule methods on the Client.
+keywords:
+  - cadence python schedules
+  - cadence python create schedule
+  - cadence python recurring workflow
+  - cadence python overlap policy
+  - cadence python backfill schedule
+permalink: /docs/python-client/schedules
+---
+
+# Schedules
+
+The Python client exposes schedule management through methods on `Client`. For a full explanation of overlap policies, backfill, catch-up, and when to use Schedules over `cron_schedule`, see the [Schedules concept page](/docs/concepts/schedules).
+
+Schedule operations use protobuf types from `cadence.api.v1.schedule_pb2`.
+
+## Getting the client
+
+```python
+from cadence.client import Client
+
+async with Client(domain="my-domain", target="localhost:7833") as client:
+    # call client.create_schedule(...), client.describe_schedule(...), etc.
+    ...
+```
+
+## Creating a schedule
+
+```python
+from datetime import timedelta
+from google.protobuf.duration import from_timedelta
+from cadence.api.v1 import common_pb2, schedule_pb2, tasklist_pb2
+
+await client.create_schedule(
+    "daily-etl",
+    spec=schedule_pb2.ScheduleSpec(
+        cron_expression="0 2 * * *",  # every day at 2 AM UTC
+    ),
+    action=schedule_pb2.ScheduleAction(
+        start_workflow=schedule_pb2.ScheduleAction.StartWorkflowAction(
+            workflow_type=common_pb2.WorkflowType(name="RunETL"),
+            task_list=tasklist_pb2.TaskList(name="etl-workers"),
+            workflow_id_prefix="daily-etl-",
+            execution_start_to_close_timeout=from_timedelta(timedelta(hours=2)),
+            task_start_to_close_timeout=from_timedelta(timedelta(seconds=10)),
+        )
+    ),
+    policies=schedule_pb2.SchedulePolicies(
+        overlap_policy=schedule_pb2.SCHEDULE_OVERLAP_POLICY_SKIP_NEW,
+        catch_up_policy=schedule_pb2.SCHEDULE_CATCH_UP_POLICY_SKIP,
+        pause_on_failure=True,
+    ),
+)
+```
+
+### Overlap policies
+
+| Constant | Behavior |
+|---|---|
+| `SCHEDULE_OVERLAP_POLICY_SKIP_NEW` (default) | Skip the new fire if a previous run is still active. |
+| `SCHEDULE_OVERLAP_POLICY_BUFFER` | Queue new fires and run them sequentially. |
+| `SCHEDULE_OVERLAP_POLICY_CONCURRENT` | Start every fire. |
+| `SCHEDULE_OVERLAP_POLICY_CANCEL_PREVIOUS` | Cancel the active run, then start the new one. |
+| `SCHEDULE_OVERLAP_POLICY_TERMINATE_PREVIOUS` | Terminate the active run immediately, then start the new one. |
+
+### Jitter
+
+```python
+spec=schedule_pb2.ScheduleSpec(
+    cron_expression="0 0 * * *",
+    jitter=from_timedelta(timedelta(minutes=10)),  # random delay up to 10 minutes
+)
+```
+
+### Bounded schedule window
+
+```python
+from google.protobuf.timestamp_pb2 import Timestamp
+import datetime
+
+spec=schedule_pb2.ScheduleSpec(
+    cron_expression="0 9 * * 1-5",
+    start_time=Timestamp(seconds=int(datetime.datetime(2026, 7, 1, tzinfo=datetime.timezone.utc).timestamp())),
+    end_time=Timestamp(seconds=int(datetime.datetime(2026, 12, 31, tzinfo=datetime.timezone.utc).timestamp())),
+)
+```
+
+## Describing a schedule
+
+```python
+resp = await client.describe_schedule("daily-etl")
+print(resp.state.paused)
+print(resp.info.next_run_time)
+print(resp.info.last_run_time)
+```
+
+## Pause and unpause
+
+```python
+# Pause with a reason
+await client.pause_schedule("daily-etl", note="INFRA-4421: cluster maintenance")
+
+# Unpause -- skip missed fires (default)
+await client.unpause_schedule(
+    "daily-etl",
+    note="maintenance complete",
+    catch_up_policy=schedule_pb2.SCHEDULE_CATCH_UP_POLICY_SKIP,
+)
+
+# Unpause -- catch up on all missed fires
+await client.unpause_schedule(
+    "daily-etl",
+    note="maintenance complete",
+    catch_up_policy=schedule_pb2.SCHEDULE_CATCH_UP_POLICY_ALL,
+)
+```
+
+### Catch-up policies
+
+| Constant | Behavior |
+|---|---|
+| `SCHEDULE_CATCH_UP_POLICY_SKIP` (default) | Resume from now; all missed fires are dropped. |
+| `SCHEDULE_CATCH_UP_POLICY_ONE` | Dispatch at most one missed fire, then resume from now. |
+| `SCHEDULE_CATCH_UP_POLICY_ALL` | Dispatch all missed fires within the catch-up window. |
+
+## Updating a schedule
+
+`update_schedule` uses a read-modify-write pattern. Pass a callback that receives the current `DescribeScheduleResponse` and mutates it in place:
+
+```python
+def change_cron(schedule):
+    schedule.spec.cron_expression = "0 3 * * *"  # move to 3 AM
+
+await client.update_schedule("daily-etl", change_cron)
+```
+
+The callback receives the full describe response. Mutate any fields you want to change; the rest are sent back unchanged.
+
+## Backfill
+
+```python
+import datetime
+from google.protobuf.timestamp_pb2 import Timestamp
+
+def ts(dt: datetime.datetime) -> Timestamp:
+    return Timestamp(seconds=int(dt.timestamp()))
+
+await client.backfill_schedule(
+    "daily-etl",
+    start_time=ts(datetime.datetime(2026, 6, 20, tzinfo=datetime.timezone.utc)),
+    end_time=ts(datetime.datetime(2026, 6, 23, tzinfo=datetime.timezone.utc)),
+    backfill_id="backfill-june-gap",
+    overlap_policy=schedule_pb2.SCHEDULE_OVERLAP_POLICY_CONCURRENT,
+)
+```
+
+`overlap_policy` is optional. If omitted, the backfill uses the schedule's configured overlap policy.
+
+## Listing schedules
+
+`list_schedules` is an async generator that handles pagination automatically:
+
+```python
+async for entry in client.list_schedules():
+    paused = entry.state.paused
+    cron = entry.cron_expression
+    wf_type = entry.workflow_type.name
+    print(f"{entry.schedule_id}: cron={cron} paused={paused} workflow={wf_type}")
+```
+
+## Deleting a schedule
+
+```python
+await client.delete_schedule("daily-etl")
+```
+
+Deleting a schedule does not cancel or terminate any workflows it already started.

--- a/docs/07-python-client/12-schedules.md
+++ b/docs/07-python-client/12-schedules.md
@@ -31,8 +31,13 @@ async with Client(domain="my-domain", target="localhost:7833") as client:
 
 ```python
 from datetime import timedelta
-from google.protobuf.duration import from_timedelta
+from google.protobuf.duration_pb2 import Duration
 from cadence.api.v1 import common_pb2, schedule_pb2, tasklist_pb2
+
+def _dur(td: timedelta) -> Duration:
+    d = Duration()
+    d.FromTimedelta(td)
+    return d
 
 await client.create_schedule(
     "daily-etl",
@@ -44,8 +49,8 @@ await client.create_schedule(
             workflow_type=common_pb2.WorkflowType(name="RunETL"),
             task_list=tasklist_pb2.TaskList(name="etl-workers"),
             workflow_id_prefix="daily-etl-",
-            execution_start_to_close_timeout=from_timedelta(timedelta(hours=2)),
-            task_start_to_close_timeout=from_timedelta(timedelta(seconds=10)),
+            execution_start_to_close_timeout=_dur(timedelta(hours=2)),
+            task_start_to_close_timeout=_dur(timedelta(seconds=10)),
         )
     ),
     policies=schedule_pb2.SchedulePolicies(
@@ -71,7 +76,7 @@ await client.create_schedule(
 ```python
 spec=schedule_pb2.ScheduleSpec(
     cron_expression="0 0 * * *",
-    jitter=from_timedelta(timedelta(minutes=10)),  # random delay up to 10 minutes
+    jitter=_dur(timedelta(minutes=10)),  # random delay up to 10 minutes
 )
 ```
 

--- a/docs/07-python-client/12-schedules.md
+++ b/docs/07-python-client/12-schedules.md
@@ -15,7 +15,24 @@ permalink: /docs/python-client/schedules
 
 The Python client exposes schedule management through methods on `Client`. For a full explanation of overlap policies, backfill, catch-up, and when to use Schedules over `cron_schedule`, see the [Schedules concept page](/docs/concepts/schedules).
 
-Schedule operations use protobuf types from `cadence.api.v1.schedule_pb2`.
+Schedule operations use protobuf types from `cadence.api.v1.schedule_pb2`. Duration fields require a `google.protobuf.Duration` object; timestamp fields require a `google.protobuf.Timestamp` object. Use the helpers below throughout your code:
+
+```python
+from datetime import timedelta
+import datetime
+from google.protobuf.duration_pb2 import Duration
+from google.protobuf.timestamp_pb2 import Timestamp
+
+def _dur(td: timedelta) -> Duration:
+    d = Duration()
+    d.FromTimedelta(td)
+    return d
+
+def _ts(dt: datetime.datetime) -> Timestamp:
+    t = Timestamp()
+    t.FromDatetime(dt)
+    return t
+```
 
 ## Getting the client
 
@@ -32,7 +49,6 @@ async with Client(domain="my-domain", target=CADENCE_TARGET) as client:
 ## Creating a schedule
 
 ```python
-from datetime import timedelta
 from cadence.api.v1 import common_pb2, schedule_pb2, tasklist_pb2
 
 await client.create_schedule(
@@ -45,14 +61,13 @@ await client.create_schedule(
             workflow_type=common_pb2.WorkflowType(name="RunETL"),
             task_list=tasklist_pb2.TaskList(name="etl-workers"),
             workflow_id_prefix="daily-etl-",
-            execution_start_to_close_timeout=timedelta(hours=2),
-            task_start_to_close_timeout=timedelta(seconds=10),
+            execution_start_to_close_timeout=_dur(timedelta(hours=2)),
+            task_start_to_close_timeout=_dur(timedelta(seconds=10)),
         )
     ),
     policies=schedule_pb2.SchedulePolicies(
         overlap_policy=schedule_pb2.SCHEDULE_OVERLAP_POLICY_SKIP_NEW,
         catch_up_policy=schedule_pb2.SCHEDULE_CATCH_UP_POLICY_SKIP,
-        pause_on_failure=True,
     ),
 )
 ```
@@ -63,28 +78,36 @@ await client.create_schedule(
 |---|---|
 | `SCHEDULE_OVERLAP_POLICY_SKIP_NEW` (default) | Skip the new fire if a previous run is still active. |
 | `SCHEDULE_OVERLAP_POLICY_BUFFER` | Queue new fires and run them sequentially. |
-| `SCHEDULE_OVERLAP_POLICY_CONCURRENT` | Start every fire. |
+| `SCHEDULE_OVERLAP_POLICY_CONCURRENT` | Start every fire up to `concurrency_limit` concurrent runs (0 = unlimited). |
 | `SCHEDULE_OVERLAP_POLICY_CANCEL_PREVIOUS` | Cancel the active run, then start the new one. |
 | `SCHEDULE_OVERLAP_POLICY_TERMINATE_PREVIOUS` | Terminate the active run immediately, then start the new one. |
+
+### SchedulePolicies fields
+
+| Field | Description |
+|---|---|
+| `overlap_policy` | How to handle a new fire when the previous run is still active. |
+| `catch_up_policy` | What to do with missed fires when the schedule resumes after downtime or unpause. |
+| `catch_up_window` | How far back to look for missed fires. |
+| `buffer_limit` | Max number of fires to queue when using `BUFFER` overlap policy. |
+| `concurrency_limit` | Max concurrent runs when using `CONCURRENT` overlap policy (0 = unlimited). |
 
 ### Jitter
 
 ```python
 spec=schedule_pb2.ScheduleSpec(
     cron_expression="0 0 * * *",
-    jitter=timedelta(minutes=10),  # random delay up to 10 minutes
+    jitter=_dur(timedelta(minutes=10)),  # random delay up to 10 minutes
 )
 ```
 
 ### Bounded schedule window
 
 ```python
-import datetime
-
 spec=schedule_pb2.ScheduleSpec(
     cron_expression="0 9 * * 1-5",
-    start_time=datetime.datetime(2026, 7, 1, tzinfo=datetime.timezone.utc),
-    end_time=datetime.datetime(2026, 12, 31, tzinfo=datetime.timezone.utc),
+    start_time=_ts(datetime.datetime(2026, 7, 1, tzinfo=datetime.timezone.utc)),
+    end_time=_ts(datetime.datetime(2026, 12, 31, tzinfo=datetime.timezone.utc)),
 )
 ```
 
@@ -141,19 +164,21 @@ The callback receives the full describe response. Mutate any fields you want to 
 
 ## Backfill
 
+`backfill_schedule` takes Python `datetime` objects directly for `start_time` and `end_time`:
+
 ```python
 import datetime
 
 await client.backfill_schedule(
     "daily-etl",
-    start_time=datetime.datetime(2026, 6, 20, tzinfo=datetime.timezone.utc),
-    end_time=datetime.datetime(2026, 6, 23, tzinfo=datetime.timezone.utc),
+    datetime.datetime(2026, 6, 20, tzinfo=datetime.timezone.utc),
+    datetime.datetime(2026, 6, 23, tzinfo=datetime.timezone.utc),
     backfill_id="backfill-june-gap",
     overlap_policy=schedule_pb2.SCHEDULE_OVERLAP_POLICY_CONCURRENT,
 )
 ```
 
-`overlap_policy` is optional. If omitted, the backfill uses the schedule's configured overlap policy.
+`overlap_policy` is optional. If omitted, the backfill uses the schedule's configured overlap policy. `backfill_id` is optional; if omitted the server generates one.
 
 ## Listing schedules
 

--- a/docs/07-python-client/12-schedules.md
+++ b/docs/07-python-client/12-schedules.md
@@ -15,18 +15,13 @@ permalink: /docs/python-client/schedules
 
 The Python client exposes schedule management through methods on `Client`. For a full explanation of overlap policies, backfill, catch-up, and when to use Schedules over `cron_schedule`, see the [Schedules concept page](/docs/concepts/schedules).
 
-Schedule operations use protobuf types from `cadence.api.v1.schedule_pb2`. Duration fields require a `google.protobuf.Duration` object; timestamp fields require a `google.protobuf.Timestamp` object. Use the helpers below throughout your code:
+Schedule operations use protobuf types from `cadence.api.v1.schedule_pb2`. Duration fields require a protobuf `Duration` object and timestamp fields require a protobuf `Timestamp` object -- use the converters below:
 
 ```python
 from datetime import timedelta
 import datetime
-from google.protobuf.duration_pb2 import Duration
+from google.protobuf.duration import from_timedelta
 from google.protobuf.timestamp_pb2 import Timestamp
-
-def _dur(td: timedelta) -> Duration:
-    d = Duration()
-    d.FromTimedelta(td)
-    return d
 
 def _ts(dt: datetime.datetime) -> Timestamp:
     t = Timestamp()
@@ -61,8 +56,8 @@ await client.create_schedule(
             workflow_type=common_pb2.WorkflowType(name="RunETL"),
             task_list=tasklist_pb2.TaskList(name="etl-workers"),
             workflow_id_prefix="daily-etl-",
-            execution_start_to_close_timeout=_dur(timedelta(hours=2)),
-            task_start_to_close_timeout=_dur(timedelta(seconds=10)),
+            execution_start_to_close_timeout=from_timedelta(timedelta(hours=2)),
+            task_start_to_close_timeout=from_timedelta(timedelta(seconds=10)),
         )
     ),
     policies=schedule_pb2.SchedulePolicies(
@@ -97,7 +92,7 @@ await client.create_schedule(
 ```python
 spec=schedule_pb2.ScheduleSpec(
     cron_expression="0 0 * * *",
-    jitter=_dur(timedelta(minutes=10)),  # random delay up to 10 minutes
+    jitter=from_timedelta(timedelta(minutes=10)),  # random delay up to 10 minutes
 )
 ```
 

--- a/docs/07-python-client/12-schedules.md
+++ b/docs/07-python-client/12-schedules.md
@@ -15,13 +15,18 @@ permalink: /docs/python-client/schedules
 
 The Python client exposes schedule management through methods on `Client`. For a full explanation of overlap policies, backfill, catch-up, and when to use Schedules over `cron_schedule`, see the [Schedules concept page](/docs/concepts/schedules).
 
-Schedule operations use protobuf types from `cadence.api.v1.schedule_pb2`. Duration fields require a protobuf `Duration` object and timestamp fields require a protobuf `Timestamp` object -- use the converters below:
+Schedule operations use protobuf types from `cadence.api.v1.schedule_pb2`. Duration and Timestamp fields require protobuf message objects -- use these helpers throughout your code:
 
 ```python
 from datetime import timedelta
 import datetime
-from google.protobuf.duration import from_timedelta
+from google.protobuf.duration_pb2 import Duration
 from google.protobuf.timestamp_pb2 import Timestamp
+
+def _dur(td: timedelta) -> Duration:
+    d = Duration()
+    d.FromTimedelta(td)
+    return d
 
 def _ts(dt: datetime.datetime) -> Timestamp:
     t = Timestamp()
@@ -56,8 +61,8 @@ await client.create_schedule(
             workflow_type=common_pb2.WorkflowType(name="RunETL"),
             task_list=tasklist_pb2.TaskList(name="etl-workers"),
             workflow_id_prefix="daily-etl-",
-            execution_start_to_close_timeout=from_timedelta(timedelta(hours=2)),
-            task_start_to_close_timeout=from_timedelta(timedelta(seconds=10)),
+            execution_start_to_close_timeout=_dur(timedelta(hours=2)),
+            task_start_to_close_timeout=_dur(timedelta(seconds=10)),
         )
     ),
     policies=schedule_pb2.SchedulePolicies(
@@ -92,7 +97,7 @@ await client.create_schedule(
 ```python
 spec=schedule_pb2.ScheduleSpec(
     cron_expression="0 0 * * *",
-    jitter=from_timedelta(timedelta(minutes=10)),  # random delay up to 10 minutes
+    jitter=_dur(timedelta(minutes=10)),  # random delay up to 10 minutes
 )
 ```
 

--- a/docs/07-python-client/12-schedules.md
+++ b/docs/07-python-client/12-schedules.md
@@ -33,13 +33,7 @@ async with Client(domain="my-domain", target=CADENCE_TARGET) as client:
 
 ```python
 from datetime import timedelta
-from google.protobuf.duration_pb2 import Duration
 from cadence.api.v1 import common_pb2, schedule_pb2, tasklist_pb2
-
-def _dur(td: timedelta) -> Duration:
-    d = Duration()
-    d.FromTimedelta(td)
-    return d
 
 await client.create_schedule(
     "daily-etl",
@@ -51,8 +45,8 @@ await client.create_schedule(
             workflow_type=common_pb2.WorkflowType(name="RunETL"),
             task_list=tasklist_pb2.TaskList(name="etl-workers"),
             workflow_id_prefix="daily-etl-",
-            execution_start_to_close_timeout=_dur(timedelta(hours=2)),
-            task_start_to_close_timeout=_dur(timedelta(seconds=10)),
+            execution_start_to_close_timeout=timedelta(hours=2),
+            task_start_to_close_timeout=timedelta(seconds=10),
         )
     ),
     policies=schedule_pb2.SchedulePolicies(
@@ -78,20 +72,19 @@ await client.create_schedule(
 ```python
 spec=schedule_pb2.ScheduleSpec(
     cron_expression="0 0 * * *",
-    jitter=_dur(timedelta(minutes=10)),  # random delay up to 10 minutes
+    jitter=timedelta(minutes=10),  # random delay up to 10 minutes
 )
 ```
 
 ### Bounded schedule window
 
 ```python
-from google.protobuf.timestamp_pb2 import Timestamp
 import datetime
 
 spec=schedule_pb2.ScheduleSpec(
     cron_expression="0 9 * * 1-5",
-    start_time=Timestamp(seconds=int(datetime.datetime(2026, 7, 1, tzinfo=datetime.timezone.utc).timestamp())),
-    end_time=Timestamp(seconds=int(datetime.datetime(2026, 12, 31, tzinfo=datetime.timezone.utc).timestamp())),
+    start_time=datetime.datetime(2026, 7, 1, tzinfo=datetime.timezone.utc),
+    end_time=datetime.datetime(2026, 12, 31, tzinfo=datetime.timezone.utc),
 )
 ```
 
@@ -108,19 +101,19 @@ print(resp.info.last_run_time)
 
 ```python
 # Pause with a reason
-await client.pause_schedule("daily-etl", note="INFRA-4421: cluster maintenance")
+await client.pause_schedule("daily-etl", reason="INFRA-4421: cluster maintenance")
 
 # Unpause -- skip missed fires (default)
 await client.unpause_schedule(
     "daily-etl",
-    note="maintenance complete",
+    reason="maintenance complete",
     catch_up_policy=schedule_pb2.SCHEDULE_CATCH_UP_POLICY_SKIP,
 )
 
 # Unpause -- catch up on all missed fires
 await client.unpause_schedule(
     "daily-etl",
-    note="maintenance complete",
+    reason="maintenance complete",
     catch_up_policy=schedule_pb2.SCHEDULE_CATCH_UP_POLICY_ALL,
 )
 ```
@@ -150,15 +143,11 @@ The callback receives the full describe response. Mutate any fields you want to 
 
 ```python
 import datetime
-from google.protobuf.timestamp_pb2 import Timestamp
-
-def ts(dt: datetime.datetime) -> Timestamp:
-    return Timestamp(seconds=int(dt.timestamp()))
 
 await client.backfill_schedule(
     "daily-etl",
-    start_time=ts(datetime.datetime(2026, 6, 20, tzinfo=datetime.timezone.utc)),
-    end_time=ts(datetime.datetime(2026, 6, 23, tzinfo=datetime.timezone.utc)),
+    start_time=datetime.datetime(2026, 6, 20, tzinfo=datetime.timezone.utc),
+    end_time=datetime.datetime(2026, 6, 23, tzinfo=datetime.timezone.utc),
     backfill_id="backfill-june-gap",
     overlap_policy=schedule_pb2.SCHEDULE_OVERLAP_POLICY_CONCURRENT,
 )

--- a/docs/07-python-client/12-schedules.md
+++ b/docs/07-python-client/12-schedules.md
@@ -15,18 +15,13 @@ permalink: /docs/python-client/schedules
 
 The Python client exposes schedule management through methods on `Client`. For a full explanation of overlap policies, backfill, catch-up, and when to use Schedules over `cron_schedule`, see the [Schedules concept page](/docs/concepts/schedules).
 
-Schedule operations use protobuf types from `cadence.api.v1.schedule_pb2`. Duration and Timestamp fields require protobuf message objects -- use these helpers throughout your code:
+Schedule operations use protobuf types from `cadence.api.v1.schedule_pb2`. Duration fields use `from_timedelta` from `google.protobuf.duration`; Timestamp fields need a small helper since no equivalent `from_datetime` exists:
 
 ```python
 from datetime import timedelta
 import datetime
-from google.protobuf.duration_pb2 import Duration
+from google.protobuf.duration import from_timedelta
 from google.protobuf.timestamp_pb2 import Timestamp
-
-def _dur(td: timedelta) -> Duration:
-    d = Duration()
-    d.FromTimedelta(td)
-    return d
 
 def _ts(dt: datetime.datetime) -> Timestamp:
     t = Timestamp()
@@ -61,8 +56,8 @@ await client.create_schedule(
             workflow_type=common_pb2.WorkflowType(name="RunETL"),
             task_list=tasklist_pb2.TaskList(name="etl-workers"),
             workflow_id_prefix="daily-etl-",
-            execution_start_to_close_timeout=_dur(timedelta(hours=2)),
-            task_start_to_close_timeout=_dur(timedelta(seconds=10)),
+            execution_start_to_close_timeout=from_timedelta(timedelta(hours=2)),
+            task_start_to_close_timeout=from_timedelta(timedelta(seconds=10)),
         )
     ),
     policies=schedule_pb2.SchedulePolicies(
@@ -97,7 +92,7 @@ await client.create_schedule(
 ```python
 spec=schedule_pb2.ScheduleSpec(
     cron_expression="0 0 * * *",
-    jitter=_dur(timedelta(minutes=10)),  # random delay up to 10 minutes
+    jitter=from_timedelta(timedelta(minutes=10)),  # random delay up to 10 minutes
 )
 ```
 

--- a/docs/07-python-client/13-testing.md
+++ b/docs/07-python-client/13-testing.md
@@ -1,0 +1,144 @@
+---
+layout: default
+title: Testing
+description: How to unit test workflows in the Cadence Python SDK using TestWorkflowEnvironment.
+keywords:
+  - cadence python testing
+  - cadence python workflow test
+  - cadence python unit test
+  - cadence python TestWorkflowEnvironment
+permalink: /docs/python-client/testing
+---
+
+# Testing
+
+`TestWorkflowEnvironment` runs workflow code in-memory without a Cadence server. It executes workflow and activity logic deterministically, mocks activities with fixed values or custom functions, and advances virtual time for timer-based workflows.
+
+## Basic test
+
+```python
+import pytest
+from cadence import Registry, workflow
+from cadence.workflow import execute_activity
+from cadence.testing import TestWorkflowEnvironment
+from datetime import timedelta
+
+registry = Registry()
+
+@registry.workflow()
+class GreetingWorkflow:
+    @workflow.run
+    async def run(self, name: str) -> str:
+        return await execute_activity(
+            "greet",
+            str,
+            name,
+            start_to_close_timeout=timedelta(seconds=5),
+        )
+
+@pytest.mark.asyncio
+async def test_greeting():
+    env = TestWorkflowEnvironment(registry)
+    env.on_activity("greet", result="Hello, World!")
+
+    client = env.client
+    await client.start_workflow(
+        "GreetingWorkflow",
+        "World",
+        workflow_id="test-greeting",
+        task_list="tl",
+        execution_start_to_close_timeout=timedelta(minutes=1),
+    )
+
+    result = env.get_workflow_result(str, workflow_id="test-greeting")
+    assert result == "Hello, World!"
+```
+
+## Mocking activities
+
+Mock an activity by name with a fixed return value:
+
+```python
+env.on_activity("fetch_order", result={"id": "123", "status": "pending"})
+```
+
+Mock with a function to inspect arguments or return dynamic values:
+
+```python
+def fake_fetch(order_id: str) -> dict:
+    assert order_id == "123"
+    return {"id": order_id, "status": "pending"}
+
+env.on_activity("fetch_order", fn=fake_fetch)
+```
+
+The mock function receives the decoded activity arguments. It can be sync or async.
+
+## Checking workflow results
+
+```python
+result = env.get_workflow_result(str, workflow_id="my-wf")
+```
+
+If the workflow failed, `get_workflow_result` re-raises the error. To inspect the error without re-raising:
+
+```python
+error = env.get_workflow_error(workflow_id="my-wf")
+```
+
+Check whether a workflow has finished:
+
+```python
+assert env.is_workflow_completed(workflow_id="my-wf")
+```
+
+## Testing signals
+
+Send a signal from the test after starting the workflow:
+
+```python
+@pytest.mark.asyncio
+async def test_approval():
+    env = TestWorkflowEnvironment(registry)
+    client = env.client
+
+    execution = await client.start_workflow(
+        "ApprovalWorkflow",
+        workflow_id="approval-test",
+        task_list="tl",
+        execution_start_to_close_timeout=timedelta(minutes=1),
+    )
+
+    await client.signal_workflow(execution.workflow_id, "", "approve", True)
+
+    result = env.get_workflow_result(bool, workflow_id="approval-test")
+    assert result is True
+```
+
+## Testing queries
+
+```python
+await client.signal_workflow("my-wf", "", "set_status", "processing")
+status = await client.query_workflow("my-wf", "", "get_status", result_type=str)
+assert status == "processing"
+```
+
+## TestWorkflowEnvironment reference
+
+| Method / Property | Description |
+|---|---|
+| `env.client` | `Client`-compatible object for starting and interacting with workflows |
+| `env.on_activity(name, result=...)` | Mock an activity with a fixed return value |
+| `env.on_activity(name, fn=...)` | Mock an activity with a callable |
+| `env.get_workflow_result(type, workflow_id="")` | Get the decoded result; raises if the workflow failed |
+| `env.get_workflow_error(workflow_id="")` | Get the error if the workflow failed, or `None` |
+| `env.is_workflow_completed(workflow_id="")` | Whether the workflow has finished |
+| `env.now()` | Current virtual time |
+| `env.close()` | Shut down the executor |
+
+`TestWorkflowEnvironment` is also a synchronous context manager:
+
+```python
+with TestWorkflowEnvironment(registry) as env:
+    ...
+```

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -124,6 +124,7 @@ const sidebars: SidebarsConfig = {
         { type: 'doc', id: 'go-client/workflow-versioning' },
         { type: 'doc', id: 'go-client/sessions' },
         { type: 'doc', id: 'go-client/distributed-cron' },
+        { type: 'doc', id: 'go-client/schedules' },
         { type: 'doc', id: 'go-client/tracing' },
         { type: 'doc', id: 'go-client/workflow-replay-shadowing' },
         { type: 'doc', id: 'go-client/workflow-non-deterministic-error' },

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -133,6 +133,26 @@ const sidebars: SidebarsConfig = {
       ],
     },
     {
+      label: 'Python Client',
+      type: 'category',
+      items: [
+        { type: 'doc', id: 'python-client/index' },
+        { type: 'doc', id: 'python-client/workers' },
+        { type: 'doc', id: 'python-client/workflows' },
+        { type: 'doc', id: 'python-client/starting-workflows' },
+        { type: 'doc', id: 'python-client/activities' },
+        { type: 'doc', id: 'python-client/child-workflows' },
+        { type: 'doc', id: 'python-client/signals' },
+        { type: 'doc', id: 'python-client/queries' },
+        { type: 'doc', id: 'python-client/retries' },
+        { type: 'doc', id: 'python-client/error-handling' },
+        { type: 'doc', id: 'python-client/continue-as-new' },
+        { type: 'doc', id: 'python-client/distributed-cron' },
+        { type: 'doc', id: 'python-client/schedules' },
+        { type: 'doc', id: 'python-client/testing' },
+      ],
+    },
+    {
       label: 'Command Line Interface',
       type: 'category',
       items: [


### PR DESCRIPTION
## What Changed

- Adds a new **Python Client** section to the docs sidebar with 14 pages covering the full `cadence-python-client` SDK surface
- All examples verified against the actual API in the [cadence-python-client](https://github.com/cadence-workflow/cadence-python-client) source and [cadence-samples](https://github.com/cadence-workflow/cadence-samples/tree/master/python_sdk_samples)

### Pages added

| Page | Content |
|---|---|
| Overview | Installation, package summary, feature coverage table |
| Workers | `Client`, `Registry`, `Worker` setup |
| Workflows | `@workflow.run`, `@workflow.signal`, `@workflow.query`, determinism constraints |
| Starting Workflows | `start_workflow`, `signal_workflow`, `query_workflow`, `cancel_workflow`, signal-with-start |
| Activities | `@activity.defn`, `@activity.method`, `execute_activity`, heartbeat |
| Child Workflows | `execute_child_workflow`, `start_child_workflow`, `ChildWorkflowFuture` |
| Signals | Signal handlers, `signal_workflow`, `signal_external_workflow` |
| Queries | Query handlers, `query_workflow`, constraints |
| Retries | `RetryPolicy` TypedDict, all fields |
| Error Handling | `ActivityFailure`, `ChildWorkflowExecutionFailed`, cancellation, error reference |
| Continue-as-New | `workflow.continue_as_new`, when to use |
| Distributed Cron | `cron_schedule` option, cron vs Schedules comparison |
| Schedules | Full schedule API (`create_schedule`, `describe_schedule`, `pause_schedule`, `unpause_schedule`, `update_schedule`, `backfill_schedule`, `list_schedules`, `delete_schedule`) |
| Testing | `TestWorkflowEnvironment`, mocking activities, signals, queries |

## Why
Python client was not part of our website

## Production Preview Verification
https://abhishekj720.github.io/Cadence-Docs/docs/python-client/index

## Test plan

- [x] `npm run build` passes with no broken links

## Potential Risks
N/A: These are just a doc additions

## Documentation Notes
N/A: Adding Python client section in our doc to reflect our additions in python client