### PR TITLE
docs(schedules): add queue state fields to observability section

### DIFF
--- a/docs/03-concepts/16-schedules.md
+++ b/docs/03-concepts/16-schedules.md
@@ -155,10 +155,14 @@ The key question is whether each scheduled time window matters independently.
 
 The `DescribeSchedule` API (and CLI command) returns:
 
-- The current schedule spec (cron expression, overlap policy, jitter)
+- The current schedule spec (cron expression, start/end bounds, jitter, overlap policy)
 - Whether the schedule is paused and the pause note
-- Recent run history (last started and last completed times)
-- The next scheduled fire time
+- Recent run history (last started and last completed times) and the next scheduled fire time
+- Lifetime counters: `total_runs`, `missed_runs` (dropped by catch-up), `skipped_runs` (dropped by overlap policy)
+- Queue state for concurrent and buffered policies:
+  - `buffered_fire_count` — number of fires currently queued in the buffer (`Buffer` overlap policy)
+  - `running_workflow_count` — number of target workflows currently executing (`Concurrent` overlap policy)
+- Active backfill progress
 
 ## Limitations
 


### PR DESCRIPTION
## What changed

Expanded the Observability section of the Schedules concept page (`docs/03-concepts/16-schedules.md`) to document fields that `DescribeSchedule` returns but were not previously listed:

- Lifetime counters: `total_runs`, `missed_runs`, `skipped_runs`
- Queue state: `buffered_fire_count` (Buffer policy) and `running_workflow_count` (Concurrent policy)
- Active backfill progress
- Clarified that spec includes start/end bounds alongside cron and jitter

## Why

These fields were added to the server and exposed via the CLI in recent releases. The docs omitted them, leaving users unaware that they can observe buffer depth and concurrent run counts from `describe`.

## How tested

Verified field names against the proto stubs (`schedule_pb2.pyi` → `ScheduleInfo.__slots__`) and against the staging3 scheduler validation run.

## Production validation

https://abhishekj720.github.io/Cadence-Docs/docs/concepts/schedules

## Potential risk

None. Documentation-only change.

## Documentation notes

N/A