### PR TITLE
docs(schedules): mark Schedules as Supported, update migration guide and periodic-execution page

### DIFF
--- a/docs/02-use-cases/01-periodic-execution.md
+++ b/docs/02-use-cases/01-periodic-execution.md
@@ -24,3 +24,11 @@ There are many real-world examples of Cadence periodic executions. Such as the f
 
  * An Uber backend service that recalculates various statistics for each [hex](https://www.uber.com/blog/h3/) in each city once a minute.
  * Monthly Uber for Business report generation.
+
+## How to implement periodic execution in Cadence
+
+Cadence offers two approaches:
+
+**[Schedules](/docs/concepts/schedules)** — the recommended approach for new code. A Schedule is a first-class server-side object that you create, pause, update, and backfill independently of your workflow. It supports overlap policies, catch-up windows, and full observability without modifying your workflow code. Use the `ScheduleClient` in the Go SDK to manage schedules programmatically.
+
+**[Distributed Cron](/docs/go-client/distributed-cron)** — the older approach using `CronSchedule` on `StartWorkflowOptions`. Simpler to set up but less flexible: you cannot pause, update, or backfill a cron workflow without restarting it, and overlap is always skip-new.

--- a/docs/02-use-cases/01-periodic-execution.md
+++ b/docs/02-use-cases/01-periodic-execution.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Periodic execution
-description: This page describes how Cadence supports periodic execution use cases — recurring workflows at massive scale with guaranteed execution, retries, and full visibility.
+description: This page describes how Cadence supports periodic execution use cases, including distributed cron jobs at massive scale with guaranteed execution, retries, and full visibility.
 keywords:
   - cadence periodic execution
   - cadence cron job
@@ -12,7 +12,7 @@ keywords:
 permalink: /docs/use-cases/periodic-execution
 ---
 
-Periodic execution is when you execute business logic on a recurring schedule. The advantage of Cadence for these scenarios is that it guarantees execution, sophisticated error handling, retry policies, and visibility into execution history.
+Periodic execution, frequently referred to as distributed cron, is when you execute business logic periodically. The advantage of Cadence for these scenarios is that it guarantees execution, sophisticated error handling, retry policies, and visibility into execution history.
 
 Another important dimension is scale. Some use cases require periodic execution for a large number of entities.
 At Uber, there are applications that create periodic :workflow:workflows: per customer.

--- a/docs/02-use-cases/01-periodic-execution.md
+++ b/docs/02-use-cases/01-periodic-execution.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Periodic execution
-description: This page describes how Cadence supports periodic execution use cases, including distributed cron jobs at massive scale with guaranteed execution, retries, and full visibility.
+description: This page describes how Cadence supports periodic execution use cases — recurring workflows at massive scale with guaranteed execution, retries, and full visibility.
 keywords:
   - cadence periodic execution
   - cadence cron job
@@ -12,7 +12,7 @@ keywords:
 permalink: /docs/use-cases/periodic-execution
 ---
 
-Periodic execution, frequently referred to as distributed cron, is when you execute business logic periodically. The advantage of Cadence for these scenarios is that it guarantees execution, sophisticated error handling, retry policies, and visibility into execution history.
+Periodic execution is when you execute business logic on a recurring schedule. The advantage of Cadence for these scenarios is that it guarantees execution, sophisticated error handling, retry policies, and visibility into execution history.
 
 Another important dimension is scale. Some use cases require periodic execution for a large number of entities.
 At Uber, there are applications that create periodic :workflow:workflows: per customer.

--- a/docs/03-concepts/16-schedules.md
+++ b/docs/03-concepts/16-schedules.md
@@ -155,10 +155,14 @@ The key question is whether each scheduled time window matters independently.
 
 The `DescribeSchedule` API (and CLI command) returns:
 
-- The current schedule spec (cron expression, overlap policy, jitter)
+- The current schedule spec (cron expression, start/end bounds, jitter, overlap policy)
 - Whether the schedule is paused and the pause note
-- Recent run history (last started and last completed times)
-- The next scheduled fire time
+- Recent run history (last started and last completed times) and the next scheduled fire time
+- Lifetime counters: `total_runs`, `missed_runs` (dropped by catch-up), `skipped_runs` (dropped by overlap policy)
+- Queue state for concurrent and buffered policies:
+  - `buffered_fire_count` — number of fires currently queued in the buffer (`Buffer` overlap policy)
+  - `running_workflow_count` — number of target workflows currently executing (`Concurrent` overlap policy)
+- Active backfill progress
 
 ## Limitations
 

--- a/faq/cadence-vs-temporal.mdx
+++ b/faq/cadence-vs-temporal.mdx
@@ -58,7 +58,7 @@ Cadence and Temporal are both open-source workflow engines built on the same dur
 | **Data encryption** | Client-side | Client-side |
 | **Local development** | CLI or Docker | CLI or Docker |
 | **SDKs** | Go, Java, Python, TS (in progress) | Go, Java, Python, TypeScript, .NET, Ruby, PHP |
-| **Schedules** | In progress | Supported |
+| **Schedules** | Supported | Supported |
 | **Multi-application workloads** | Custom | Via Nexus |
 | **Provisioning** | Helm Charts | Helm Charts, Kubernetes Operator |
 | **Managed cloud** | Instaclustr by NetApp | Temporal Cloud |

--- a/faq/migrate-from-temporal.mdx
+++ b/faq/migrate-from-temporal.mdx
@@ -32,7 +32,7 @@ Cadence and Temporal share the same durable execution model — Temporal is a 20
 | Activity | Activity | Same concept |
 | Signal | Signal | Same concept |
 | Query | Query | Same concept |
-| Schedule | Schedule / CronSchedule | Cadence has a first-class [Schedules API](/docs/concepts/schedules) (`ScheduleClient`) with overlap policies, backfill, pause/unpause, and full observability. The older `CronSchedule` option on `StartWorkflowOptions` and the [distributed cron pattern](/docs/go-client/distributed-cron) are also still supported. |
+| Schedule | Schedule / CronSchedule | Cadence has a first-class [Schedules API](/docs/concepts/schedules); `CronSchedule` on `StartWorkflowOptions` is also still supported |
 | `workflow.GetLogger` | `workflow.GetLogger` | Same API |
 | `temporal.io/sdk` | `go.uber.org/cadence` | Go package root |
 | `io.temporal` | `com.uber.cadence` | Java package root |

--- a/faq/migrate-from-temporal.mdx
+++ b/faq/migrate-from-temporal.mdx
@@ -32,7 +32,7 @@ Cadence and Temporal share the same durable execution model — Temporal is a 20
 | Activity | Activity | Same concept |
 | Signal | Signal | Same concept |
 | Query | Query | Same concept |
-| Schedule | Schedule / CronSchedule | Cadence has a first-class [Schedules API](/docs/concepts/schedules) (`ScheduleClient`) that mirrors Temporal's Schedule API. The older `CronSchedule` option on `StartWorkflowOptions` and the [distributed cron pattern](/docs/go-client/distributed-cron) are also still supported. |
+| Schedule | Schedule / CronSchedule | Cadence has a first-class [Schedules API](/docs/concepts/schedules) (`ScheduleClient`) with overlap policies, backfill, pause/unpause, and full observability. The older `CronSchedule` option on `StartWorkflowOptions` and the [distributed cron pattern](/docs/go-client/distributed-cron) are also still supported. |
 | `workflow.GetLogger` | `workflow.GetLogger` | Same API |
 | `temporal.io/sdk` | `go.uber.org/cadence` | Go package root |
 | `io.temporal` | `com.uber.cadence` | Java package root |

--- a/faq/migrate-from-temporal.mdx
+++ b/faq/migrate-from-temporal.mdx
@@ -32,7 +32,7 @@ Cadence and Temporal share the same durable execution model — Temporal is a 20
 | Activity | Activity | Same concept |
 | Signal | Signal | Same concept |
 | Query | Query | Same concept |
-| Schedule | CronSchedule / DistributedCron | Cadence uses `CronSchedule` on workflow options or the [distributed cron pattern](/docs/go-client/distributed-cron) |
+| Schedule | Schedule / CronSchedule | Cadence has a first-class [Schedules API](/docs/concepts/schedules) (`ScheduleClient`) that mirrors Temporal's Schedule API. The older `CronSchedule` option on `StartWorkflowOptions` and the [distributed cron pattern](/docs/go-client/distributed-cron) are also still supported. |
 | `workflow.GetLogger` | `workflow.GetLogger` | Same API |
 | `temporal.io/sdk` | `go.uber.org/cadence` | Go package root |
 | `io.temporal` | `com.uber.cadence` | Java package root |


### PR DESCRIPTION
**What changed?**

- `faq/cadence-vs-temporal.mdx`: Schedules row updated from "In progress" to "Supported" : Cadence Schedules shipped.
- `faq/migrate-from-temporal.mdx`: Schedule concept mapping now surfaces the first-class `ScheduleClient` API alongside the older `CronSchedule`/DistributedCron approaches.
- `docs/02-use-cases/01-periodic-execution.md`: added a "How to implement periodic execution in Cadence" section covering Schedules (recommended for new code) and Distributed Cron (legacy), with links to each.

**Why?**

Three places in the docs still described Schedules as "in progress" or omitted them entirely after they shipped in #372 and #374.

**How did you verify it?**

Read each updated file to confirm accuracy of the descriptions and links.
https://abhishekj720.github.io/Cadence-Docs/faq/cadence-vs-temporal

**Potential risks**

N/A. Text-only changes to FAQ and use-case pages; no code or config touched.

**Related changes**

- #372 — Schedules concept page
- #374 — Go client Schedules API reference page