### PR TITLE
faq(cadence-vs-temporal): restore original page structure and mark Schedules as supported

### DIFF
--- a/faq/cadence-vs-temporal.mdx
+++ b/faq/cadence-vs-temporal.mdx
@@ -1,103 +1,120 @@
 ---
 layout: default
-title: "Cadence vs Temporal: Feature Comparison & Key Differences"
-description: Side-by-side comparison of Cadence and Temporal workflow engines — features, SDKs, pricing, governance, and deployment. Cadence is the open-source, CNCF-hosted predecessor that Temporal was forked from in 2019.
+title: Cadence vs Temporal
+description: This page explains the differences between Cadence and Temporal and helps you decide which one to use.
 keywords:
   - cadence vs temporal
-  - temporal vs cadence
-  - cadence workflow vs temporal
-  - uber cadence vs temporal
-  - cadence vs temporal comparison
-  - cadence temporal differences
-  - workflow engine comparison
-  - temporal alternative
-  - temporal cost
-  - cadence cost
+  - cadence
+  - temporal
+  - comparison
+  - features
+  - differences
+  - advantages
+  - disadvantages
+  - benefits
+  - drawbacks
+  - pros and cons
+  - matrix
+  - table
+  - chart
 permalink: /faq/cadence-vs-temporal
 ---
 
-
-# Cadence vs Temporal: Key Differences
-
-Cadence and Temporal are both open-source workflow engines built on the same durable execution model — Temporal is a 2019 fork of Cadence. Since the fork they've diverged: Temporal prioritized ecosystem breadth and commercial distribution; Cadence focused on reliability, multi-tenancy, and cost-efficiency at very high scale.
-
-:::tip TL;DR
-- **Same core model**: both use durable execution — workflows survive crashes, retries are automatic, timers persist.
-- **Cadence scales higher**: 4,000+ domains at Uber, true multi-tenancy with noisy-neighbor isolation, higher throughput ceilings.
-- **Cadence is 10x cheaper**: infrastructure-based pricing (nodes/storage) vs. Temporal's per-action billing.
-- **Cadence is community-governed**: CNCF Sandbox under the Linux Foundation — no single vendor controls the roadmap.
-:::
-
-## Which should you choose?
-
-| If you… | Choose |
-|---|---|
-| Need .NET, Ruby, or PHP SDKs today | **Temporal** |
-| Are running at very high scale (thousands of domains, billions of workflows/month) | **Cadence** |
-| Want predictable infrastructure-based cost that doesn't scale with usage | **Cadence** |
-| Want a vendor-managed cloud offering with minimal ops overhead | **Temporal Cloud** |
-| Want open-source with no vendor lock-in and community governance (CNCF) | **Cadence** |
-| Are migrating from an existing Temporal deployment | [See migration guide](/faq/migrate-from-temporal) |
-| Need Nexus for multi-application workloads today | **Temporal** |
-| Run Go or Java workflows at scale | Either — see full comparison below |
-
 ## Feature Comparison
 
+### Similar/Common in Both
 | Feature | Cadence | Temporal |
 | ----- | ----- | ----- |
-| **Long-running workflows** | Supported | Supported |
-| **Distributed cron** | Supported | Supported |
-| **Signals** | Supported | Supported |
-| **Batch processing** | Supported | Supported |
-| **AI / agent orchestration** | Supported | Supported |
+| **Long Running Workflows** | Supported | Supported |
+| **Distributed Cron** | Supported | Supported |
+| **Singleton in Distributed Env** | Supported | Supported |
+| **Synchronous Interactions (Signals)** | Supported | Supported |
+| **Batch Processing** | Supported | Supported |
+| **AI/Agent Orchestration** | Supported | Supported |
 | **TLS** | Supported | Supported |
-| **Multi-region replication** | Supported | Supported |
-| **Observability** | Prometheus / Grafana | Prometheus / Grafana |
+| **Tenancy/Context Propagation** | Supported | Supported |
+| **Schedules** | Supported | Supported |
 | **Persistence** | Cassandra, MySQL, PostgreSQL | Cassandra, MySQL, PostgreSQL |
 | **Visibility** | OpenSearch, Elasticsearch, Pinot, and above DBs | OpenSearch, Elasticsearch, and above DBs |
-| **Data encryption** | Client-side | Client-side |
-| **Local development** | CLI or Docker | CLI or Docker |
-| **SDKs** | Go, Java, Python, TS (in progress) | Go, Java, Python, TypeScript, .NET, Ruby, PHP |
-| **Schedules** | Supported | Supported |
-| **Multi-application workloads** | Custom | Via Nexus |
-| **Provisioning** | Helm Charts | Helm Charts, Kubernetes Operator |
-| **Managed cloud** | Instaclustr by NetApp | Temporal Cloud |
-| **Cost model** | Infrastructure-based (nodes + storage) | Per-action (state transitions) |
-| **Governance** | CNCF Sandbox — Linux Foundation | Commercial — Temporal Technologies |
-| **Multi-tenancy** | 2,000+ domains per environment, auto noisy-neighbor isolation | Not supported |
-| **Domain replication** | Active-Active | Active-Passive |
-| **Zonal isolation** | Supported | Not supported |
-| **Custom workflow controls** | Supported | Not supported |
-| **Adaptive tasklist scaling** | Supported | Not supported |
-| **Async workflow fan-out** | Millions of starts/signals per second | Not supported |
-| **Batch futures** | Built-in | Not built-in |
-| **Global quota management** | Supported | Not supported |
-| **Rate limit granularity** | Per-workflow | Per-domain |
-| **Test traffic region forwarding** | Supported | Not supported |
-| **Deployment flexibility** | Self-host, AWS/Azure/GCP, or managed | Self-host or Temporal Cloud |
+| **Data Encryption** | Client-side encryption | Client-side encryption |
+| **Local Development** | CLI or Docker | CLI or Docker |
+| **Multi-Region** | Global Namespaces (Multi-cluster replication) | Global Namespaces (Multi-cluster replication) |
+| **Observability** | Prometheus/Grafana Web UI (MultiEnvironment, Batch Operations) | Prometheus/Grafana Web UI (Single Environment) |
+| **Pricing Model** | Infrastructure-based (Nodes/Storage) | Pay-per-Action (State transitions) |
+
+
+### Temporal is Better
+| Feature | Cadence | Temporal |
+| ----- | ----- | ----- |
+| **Payload Metadata** | Workflows, Activities, Signals | Workflows, Activities, Signals, Decisions |
+| **SDKs** | Go, Java, Python, TS (in progress) | Go, Java, Python, TS, .NET, Ruby, PHP |
+| **Multi-application workloads** | Custom | via Nexus |
+| **Provisioning** | Helm Charts | Helm Charts, K8s Operator |
+
+
+### No Shared Temporal Data
+| Feature | Cadence | Temporal |
+| ----- | ----- | ----- |
+| **Multi-tenancy** | Environments with 2K+ domains Auto noisy neighbor isolation features | *No shared data* |
+| **Replication Latency** | 2s (Cassandra) | *No shared data* |
+
+### Cadence is Better
+| Feature | Cadence | Temporal |
+| ----- | ----- | ----- |
+| **Managed Cost** | [78% cheaper](https://www.instaclustr.com/blog/cadence-vs-temporal-understanding-workflow-orchestration-and-temporal-cloud-pricing/) for the same scale |  |
+| **Management** | Self-host, AWS/Azure/GCP (separate or users' own env) | Self-host, Temporal Cloud |
+| **Governance** | CNCF Sandbox (Community-led) | Commercial (Temporal Technologies) |
+| **Domains** | Active-Active | Active-Passive |
+| **Custom Workflow Controls** | Supported | Not Supported |
+| **Zonal Isolation** | Supported | Not Supported |
+| **Adaptive User Workload Scaling** | Adaptive Tasklist Partitions, Worker Autoscaling | Worker Autoscaling |
+| **Max Throughput** | Higher limits achieved with secondary sharding using multiple DB instances | Limited by the storage technology |
+| **Async Workflows** | Supported (allows starting/signaling millions of workflows per second) | Not Supported |
+| **Batch Futures** | Built-in | Custom (user needs to implement it) |
+| **Quota Management** | Global Ratelimiters; guaranteed quotas | Per host, traffic skews create quota bottlenecks |
+| **Rate Limit Granularity** | Down to Per Workflow Rate Limits (Least possible disruption against noisy neighbors) | Down to Per Domain Rate Limits |
+| **Test Traffic Region Forwarding** | Supported | Not Supported |
+
+*Note that this is a live document which is expected to be updated with changing features from both sides. You can raise a PR to update in the [Cadence-Docs repo](https://github.com/cadence-workflow/Cadence-Docs) as well as find the update history.*
+
+**Why does the gap exist in the first place?**
+
+Since the separation of Cadence and Temporal, the two projects have focused on distinct operation goals. Temporal prioritized expanding its ecosystem and broadening its user base. In contrast, Cadence focused on deep investments in reliability, scalability, and cost-efficiency to keep pace with exponential growth within massive production environments.
+
+The impact of this focus is best illustrated by the project's evolution at Uber. At the time these projects diverged, Uber managed fewer than 100 domains; today, that figure has grown to over 4,000. Currently, a single Cadence environment can host more than 2,000 domains with total isolation, ensuring zero "noisy neighbor" issues even at this extreme scale.
 
 ## Background
 
-Temporal is a fork of Cadence created in 2019 as an independent GitHub repository. Both projects trace their lineage to Amazon SWF ([2012](https://aws.amazon.com/about-aws/whats-new/2012/02/21/aws-announces-swf/)) and Azure Durable Functions ([2017](https://arxiv.org/abs/1807.11248)) — you can read the [history of this architecture](https://temporal.io/blog/building-resilient-workflows-from-azure-to-cadence-to-temporal) or view the [licensing documentation](https://github.com/cadence-workflow/cadence-java-client/blob/master/LICENSE.txt).
+Temporal is a fork of Cadence that exists as an independent Github repository instead of a linked project.
 
-Since 2019, Temporal focused on SDK breadth and commercial distribution. Cadence focused on reliability, scalability, and multi-tenancy at extreme scale. At Uber, Cadence has grown from fewer than 100 domains at fork time to over 4,000 today, facilitating billions of workflows and hundreds of billions of updates every month.
+Cadence leverages the expertise of the original Amazon SWF ([2012](https://aws.amazon.com/about-aws/whats-new/2012/02/21/aws-announces-swf/)) and Azure Durable Functions ([2017](https://arxiv.org/abs/1807.11248)) creators. You can explore the [history of this architecture](https://temporal.io/blog/building-resilient-workflows-from-azure-to-cadence-to-temporal) or view the [licensing documentation](https://github.com/cadence-workflow/cadence-java-client/blob/master/LICENSE.txt) that confirms its foundational roots in SWF.
 
-## Vendor lock-in concerns
+Both projects are currently active and receive regular maintenance. However, since 2019, they have diverged to meet different market demands. Neither is objectively superior; they are simply optimized for different outcomes, as detailed in the comparison below.
 
-This is the most significant structural difference between the two projects. Temporal Technologies is a commercial company whose managed cloud offering (Temporal Cloud) is the primary distribution. Features, improvements, and roadmap priorities are shaped by commercial incentives.
+## Vendor Lock Concerns
 
-Cadence is a [CNCF Sandbox project](https://www.cncf.io/projects/cadence-workflow/) under the Linux Foundation with an [open governance structure](/community/governance). Any company or individual can contribute and rise to the Technical Steering Committee. No single vendor controls the roadmap.
+This represents the most significant difference between the two projects. A common issue when open-source software is forked for commercial sale.
 
-For technologies like these — where SDKs are deeply integrated into your codebase — the cost of migration is exceptionally high. Choosing a community-governed project reduces long-term pricing, roadmap, and vendor lock-in risk.
+In many cases, vendors gate premium features under different names to create "vendor lock-in," securing lifetime business relationships. For technologies like these, which rely on SDKs and are deeply integrated into your codebase, the cost of a later migration is exceptionally high.
 
-## Open source & open governance
+Similarly, vendors may offer open-source versions but reserve the most critical features and improvements exclusively for their managed solutions.
 
-[Cadence](https://www.cncf.io/projects/cadence-workflow/) operates under an open governance model with an ecosystem of ~150 companies and an [Excellent Health Score](https://insights.linuxfoundation.org/project/cadence) from the Linux Foundation. Because over 90% of Cadence maintainers are also active users, the project is user-first — not profit-first.
+While single-vendor dependency carries long-term risks for pricing and support, fully open-source projects like Cadence are community-owned. This ensures you have the freedom to self-host or choose from multiple service providers. This commitment to transparency and independence is the primary reason the Cadence project continues to see active investment and maintenance.
 
-Recent examples of this focus: the [worker autoscaler](/blog/2026/01/13/2026-01-13-cadence-in-2025/cadence-in-2025#cadence-worker-auto-scaler), which optimizes workers running outside of Cadence, and [noisy neighbor isolation](/blog/2026/01/13/2026-01-13-cadence-in-2025/cadence-in-2025#history-queues-v2), which allows thousands of domains to share an environment with zero disruption.
+## Open Source & Open Governance
 
-## Coming from Temporal?
+[Cadence](https://www.cncf.io/projects/cadence-workflow/) is a [CNCF](https://www.cncf.io/) project under [the Linux Foundation](https://www.linuxfoundation.org/) with an [Excellent Health Score](https://insights.linuxfoundation.org/project/cadence). It operates under an [open governance structure](https://cadenceworkflow.io/community/governance) with an ecosystem that includes ~150 companies. At Uber alone, Cadence facilitates billions of workflows and hundreds of billions of updates every month ([Adopters List](https://github.com/cadence-workflow/cadence/blob/master/ADOPTERS.md), [Scale Overview](https://www.youtube.com/watch?v=UmCFfEpAqNg), [Uber Case Study](https://www.youtube.com/watch?v=-qj_Lb_basY), [Cloudera Integration](https://docs.cloudera.com/machine-learning/1.5.4/quota-management/topics/ml-quota-mgt-enable.html)).
 
-If you're currently running Temporal and want to evaluate Cadence, see the [Cadence migration guide](/faq/migrate-from-temporal) for a step-by-step walkthrough of the differences and migration path.
+These factors are essential when evaluating project maturity, risk, and long-term viability. The Cadence project features maintainers and contributors from a wide range of companies, with advancement based on commitment and past contributions. Any company or individual can start as a contributor and rise to the Technical Steering Committee by meeting eligibility requirements and gaining approval from official members.
 
-*This is a live document. You can [raise a PR](https://github.com/cadence-workflow/Cadence-Docs) to update the comparison as features evolve on either side.*
+This is a proven model that builds a healthy ecosystem where the companies most involved in the project can participate in decision-making, rather than simply requesting features from a vendor. This commitment to meritocracy and diversity ensures that the resulting open-source projects are truly best-in-class.
+
+Because over 90% of Cadence maintainers and contributors are also active users, the project focuses on building superior software without the bias of commercial profit motives. This user-first perspective drives high-impact projects like the [worker autoscaler](https://cadenceworkflow.io/blog#cadence-worker-auto-scaler), which optimizes workers operating outside of Cadence, and automated [noisy neighbor isolation](https://cadenceworkflow.io/blog#history-queues-v2), which allows multiple Cadence domains to be hosted in a single environment without disruption.
+
+## Managed Solutions & Pricing
+
+Managed Temporal is provided by Temporal Technologies, while managed Cadence is offered by Instaclustr by NetApp. Since Cadence's inclusion in the CNCF, interest in managed hosting options has surged as more organizations look for enterprise-grade support ([Community Discussion](https://github.com/cadence-workflow/cadence/issues/7830)).
+
+Managed Cadence can be [approximately 78% more cost-effective](https://www.instaclustr.com/blog/cadence-vs-temporal-understanding-workflow-orchestration-and-temporal-cloud-pricing/) than Temporal for comparable configurations. This is primarily due to the Cadence pricing model, which is based on resource usage (CPU, memory, and disk) rather than "per-call" metrics. At high scales, this host-based approach is far more efficient and predictable than call-based pricing. Furthermore, Cadence offers the flexibility of on-premises deployment and support-only contracts. Our maintainers partner closely with all vendors to ensure the success of every deployment.
+
+In addition to vendor options, Cadence maintainers provide direct, voluntary assistance to help users navigate the journey from their first local run to a successful production launch. This community-led onboarding is a completely free resource for those getting started. You can reach us through our primary [CNCF #cadence-users channel](https://communityinviter.com/apps/cloud-native/cncf) or our [dedicated Slack workspace](https://join.slack.com/t/uber-cadence/shared_invite/zt-3sdz5oow2-TXL478KDhHvJOuUm0nItiQ). As with the best open-source projects, we believe that investing in our users' success today drives the future contributions that keep the ecosystem thriving.


### PR DESCRIPTION
## What changed
- Restores the original four-section table layout (Similar/Common in Both, Temporal is Better, No Shared Temporal Data, Cadence is Better) that was lost in a prior rewrite
- Restores the original narrative sections: Vendor Lock Concerns, Open Source & Open Governance, Managed Solutions & Pricing, and the "Why does the gap exist" explanation
- Moves **Schedules** from "Temporal is Better" to "Similar/Common in Both", with Cadence status updated from "In progress" to "Supported" (server-side schedules shipped and validated in production)

## Why
The original structure communicates the positioning more clearly and is the version that has been shared externally.

## How tested
deployed on personal branch

## Production validation
https://abhishekj720.github.io/Cadence-Docs/faq/cadence-vs-temporal

## Potential risk
None.

## Documentation notes
N/A