### PR TITLE
feat(community): add email subscribe widget and revamp community pages

### DIFF
--- a/community/contact-us.mdx
+++ b/community/contact-us.mdx
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Contact Us
-description: This page provides all the ways to contact the Cadence community, including Slack channels, social media, Reddit, GitHub Discussions, and Stack Overflow.
+description: "Connect with the Cadence community: subscribe to updates, join Slack and Discord, follow us on GitHub, LinkedIn, and Reddit, or reach the maintainers directly."
 keywords:
   - cadence contact
   - cadence slack
@@ -16,45 +16,52 @@ keywords:
 permalink: /community/contact-us
 ---
 
-Looking for help with Cadence or a managed solution? Are you interested in contributing to Cadence? Anything else? Here are some ways to get in touch with the Cadence community.
+import MailingListSignup from '@site/src/components/MailingListSignup';
 
-## Mailing List
-- [cncf-cadence-maintainers on CNCF Groups](https://lists.cncf.io/g/cncf-cadence-maintainers): reach the Cadence maintainers directly via email
+**Cadence is an open-source project built by and for its community.** Whether you need help with your deployment, want to contribute, or just want to stay informed — there is a channel for you below.
 
-## Slack
-- [Cadence Community on CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) (primary medium of contact for users)
-  - Join the **#cadence-users** channel to ask questions and get help
-  - Join the **#cadence-contributors** channel for help contributing to Cadence
-  - Join the **#cadence-maintainers** channel to reach the Cadence maintainers
+<MailingListSignup
+  headline="Join the Cadence community"
+  tagline="Subscribe for meetup announcements, release notes, and community news."
+/>
 
-Alternatively:
-- [Join our Slack workspace](https://join.slack.com/t/uber-cadence/shared_invite/zt-3sdz5oow2-TXL478KDhHvJOuUm0nItiQ)
+## Real-time chat
 
-## Social Media
-- [/cadenceworkflow on LinkedIn](https://www.linkedin.com/company/cadenceworkflow/) (primary channel for updates and announcements)
-- [@cadence-workflow on YouTube](https://www.youtube.com/@cadence-workflow)
-- [@cadenceworkflow on X](https://x.com/cadenceworkflow) (occasional updates)
-- [r/cadenceworkflow on Reddit](https://www.reddit.com/r/cadenceworkflow/)
+The fastest way to get help or connect with contributors:
 
-## News
-- [Cadence Workflow Blog](/blog)
+- **CNCF Slack** — [communityinviter.com/apps/cloud-native/cncf](https://communityinviter.com/apps/cloud-native/cncf) (primary contact channel)
+  - `#cadence-users` — questions, production help, general discussion
+  - `#cadence-contributors` — help contributing code or docs
+  - `#cadence-maintainers` — reach the core team directly
+- **Discord** — [discord.gg/ynvjm2Et5](https://discord.gg/ynvjm2Et5) (alternative real-time chat)
+- **Uber Cadence Slack** — [join workspace](https://join.slack.com/t/uber-cadence/shared_invite/zt-3sdz5oow2-TXL478KDhHvJOuUm0nItiQ) (legacy workspace, still monitored)
 
 ## GitHub
-- [Cadence Community on GitHub Discussions](https://github.com/cadence-workflow/cadence/discussions)
 
-If you have a feature request or a bug to report, file an issue in the appropriate Cadence GitHub repository:
+- **Discussions** — [cadence-workflow/cadence/discussions](https://github.com/cadence-workflow/cadence/discussions) — longer-form questions, proposals, and announcements
+- **Issues** — file bugs and feature requests in the relevant repository:
+  - [Cadence Server](https://github.com/cadence-workflow/cadence)
+  - [Go SDK](https://github.com/cadence-workflow/cadence-go-client) / [Go Samples](https://github.com/cadence-workflow/cadence-samples)
+  - [Java SDK](https://github.com/cadence-workflow/cadence-java-client) / [Java Samples](https://github.com/cadence-workflow/cadence-java-samples)
+  - [Python SDK](https://github.com/cadence-workflow/cadence-python-client)
+  - [Helm Charts](https://github.com/cadence-workflow/cadence-charts)
+  - [Web UI](https://github.com/cadence-workflow/cadence-web)
+  - [Full GitHub org](https://github.com/cadence-workflow)
 
-* [Cadence Server](https://github.com/cadence-workflow/cadence)
-* [Cadence Go SDK](https://github.com/cadence-workflow/cadence-go-client)
-* [Cadence Go Samples](https://github.com/cadence-workflow/cadence-samples)
-* [Cadence Java SDK](https://github.com/cadence-workflow/cadence-java-client)
-* [Cadence Java Samples](https://github.com/cadence-workflow/cadence-java-samples)
-* [Cadence Helm Charts](https://github.com/cadence-workflow/cadence-charts)
-* [Cadence Python SDK](https://github.com/cadence-workflow/cadence-python-client)
-* [Cadence Web UI](https://github.com/cadence-workflow/cadence-web)
+## Maintainer mailing list
 
-There are more repositories in the [Cadence GitHub organization](https://github.com/cadence-workflow). Please choose the repository that best matches your issue.
+To reach the Cadence maintainers directly via email: [cncf-cadence-maintainers on CNCF Groups](https://lists.cncf.io/g/cncf-cadence-maintainers).
+
+For general community updates and meetup announcements, use the subscribe form above.
+
+## Social and news
+
+- **LinkedIn** — [@cadenceworkflow](https://www.linkedin.com/company/cadenceworkflow/) — primary channel for project news and announcements
+- **YouTube** — [@cadence-workflow](https://www.youtube.com/@cadence-workflow) — meetup recordings, demos, and talks
+- **Reddit** — [r/cadenceworkflow](https://www.reddit.com/r/cadenceworkflow/)
+- **X** — [@cadenceworkflow](https://x.com/cadenceworkflow) — occasional updates
+- **Blog** — [cadenceworkflow.io/blog](/blog)
 
 ## Stack Overflow
 
-We only monitor Stack Overflow occasionally. You can still try the [cadence-workflow](https://stackoverflow.com/questions/tagged/cadence-workflow) tag. For a faster response, use the channels above.
+The [`cadence-workflow`](https://stackoverflow.com/questions/tagged/cadence-workflow) tag is monitored occasionally. For a faster response, Slack is preferred.

--- a/community/contact-us.mdx
+++ b/community/contact-us.mdx
@@ -18,7 +18,7 @@ permalink: /community/contact-us
 
 import MailingListSignup from '@site/src/components/MailingListSignup';
 
-**Cadence is an open-source project built by and for its community.** Whether you need help with your deployment, want to contribute, or just want to stay informed — there is a channel for you below.
+**Cadence is an open-source project built by and for its community.** Whether you need help with your deployment, want to contribute, or just want to stay informed; there is a channel for you below.
 
 <MailingListSignup
   headline="Join the Cadence community"
@@ -29,17 +29,17 @@ import MailingListSignup from '@site/src/components/MailingListSignup';
 
 The fastest way to get help or connect with contributors:
 
-- **CNCF Slack** — [communityinviter.com/apps/cloud-native/cncf](https://communityinviter.com/apps/cloud-native/cncf) (primary contact channel)
-  - `#cadence-users` — questions, production help, general discussion
-  - `#cadence-contributors` — help contributing code or docs
-  - `#cadence-maintainers` — reach the core team directly
-- **Discord** — [discord.gg/ynvjm2Et5](https://discord.gg/ynvjm2Et5) (alternative real-time chat)
-- **Uber Cadence Slack** — [join workspace](https://join.slack.com/t/uber-cadence/shared_invite/zt-3sdz5oow2-TXL478KDhHvJOuUm0nItiQ) (legacy workspace, still monitored)
+- **CNCF Slack**: [communityinviter.com/apps/cloud-native/cncf](https://communityinviter.com/apps/cloud-native/cncf) (primary contact channel)
+  - `#cadence-users`: questions, production help, general discussion
+  - `#cadence-contributors`: help contributing code or docs
+  - `#cadence-maintainers`: reach the core team directly
+- **Discord**: [discord.gg/ynvjm2Et5](https://discord.gg/ynvjm2Et5) (alternative real-time chat)
+- **Uber Cadence Slack**: [join workspace](https://join.slack.com/t/uber-cadence/shared_invite/zt-3sdz5oow2-TXL478KDhHvJOuUm0nItiQ) (legacy workspace, still monitored)
 
 ## GitHub
 
-- **Discussions** — [cadence-workflow/cadence/discussions](https://github.com/cadence-workflow/cadence/discussions) — longer-form questions, proposals, and announcements
-- **Issues** — file bugs and feature requests in the relevant repository:
+- **Discussions**: [cadence-workflow/cadence/discussions](https://github.com/cadence-workflow/cadence/discussions): longer-form questions, proposals, and announcements
+- **Issues**: file bugs and feature requests in the relevant repository:
   - [Cadence Server](https://github.com/cadence-workflow/cadence)
   - [Go SDK](https://github.com/cadence-workflow/cadence-go-client) / [Go Samples](https://github.com/cadence-workflow/cadence-samples)
   - [Java SDK](https://github.com/cadence-workflow/cadence-java-client) / [Java Samples](https://github.com/cadence-workflow/cadence-java-samples)
@@ -56,11 +56,11 @@ For general community updates and meetup announcements, use the subscribe form a
 
 ## Social and news
 
-- **LinkedIn** — [@cadenceworkflow](https://www.linkedin.com/company/cadenceworkflow/) — primary channel for project news and announcements
-- **YouTube** — [@cadence-workflow](https://www.youtube.com/@cadence-workflow) — meetup recordings, demos, and talks
-- **Reddit** — [r/cadenceworkflow](https://www.reddit.com/r/cadenceworkflow/)
-- **X** — [@cadenceworkflow](https://x.com/cadenceworkflow) — occasional updates
-- **Blog** — [cadenceworkflow.io/blog](/blog)
+- **LinkedIn**: [@cadenceworkflow](https://www.linkedin.com/company/cadenceworkflow/) (primary channel for project news and announcements)
+- **YouTube**: [@cadence-workflow](https://www.youtube.com/@cadence-workflow) (meetup recordings, demos, and talks)
+- **Reddit**: [r/cadenceworkflow](https://www.reddit.com/r/cadenceworkflow/)
+- **X**: [@cadenceworkflow](https://x.com/cadenceworkflow) (occasional updates)
+- **Blog**: [cadenceworkflow.io/blog](/blog)
 
 ## Stack Overflow
 

--- a/community/meetup.mdx
+++ b/community/meetup.mdx
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Community Meetups
-description: Join the Cadence community meetup — a recurring gathering for Cadence users and contributors to share demos, ask questions, and connect with maintainers.
+description: Join the Cadence community meetup, a recurring gathering for Cadence users and contributors to share demos, ask questions, and connect with maintainers.
 keywords:
   - cadence meetup
   - cadence community meetup
@@ -36,7 +36,7 @@ import TabItem from '@theme/TabItem';
 
 <Tabs>
   <TabItem value="slack" label="Slack" default>
-    Join the [**#cadence-users** channel on CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) — meetup announcements are posted there first.
+    Join the [**#cadence-users** channel on CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf): meetup announcements are posted there first.
   </TabItem>
   <TabItem value="github" label="GitHub">
     Watch the [cadence-workflow GitHub org](https://github.com/cadence-workflow) for event announcements.

--- a/community/meetup.mdx
+++ b/community/meetup.mdx
@@ -14,50 +14,55 @@ permalink: /community/meetup
 ---
 
 import MailingListSignup from '@site/src/components/MailingListSignup';
-
-# Community Meetups
-
-The Cadence community meetup is a recurring gathering for users, contributors, and maintainers. Each session includes demos, open Q&A, and updates from the core team.
-
-Whether you are evaluating Cadence, running it in production, or contributing to the project, the meetup is the fastest way to get answers, see what others are building, and connect directly with maintainers.
-
-<MailingListSignup
-  id="stay-updated-on-cadence"
-  headline="Stay updated on Cadence"
-  tagline="Subscribe to get meetup announcements, release notes, and community updates."
-/>
-
-## Upcoming meetup
-
-Details for the next session will be posted here. To get notified first:
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+# Community Meetups
+
+The Cadence community meetup is a live, recurring session where users, contributors, and maintainers come together to share what they're building, ask hard questions, and hear directly from the core team. Every session includes demos, open Q&A, and maintainer updates.
+
+Whether you're evaluating Cadence, running it in production, or ready to contribute, the meetup is the fastest path to real answers and real people.
+
+## Next session
+
+:::info Upcoming meetup
+**Date:** To be announced.
+
+Subscribe below to be the first to know when the next session is scheduled. Past recordings are on [YouTube](https://www.youtube.com/@cadenceworkflow) while you wait.
+:::
+
+<MailingListSignup
+  id="stay-updated-on-cadence"
+  headline="Get notified for the next meetup"
+  tagline="Subscribe to the CNCF Cadence Community list and be the first to hear when the date drops."
+/>
+
+## What to expect
+
+| Session segment | What happens |
+|---|---|
+| **Demos** | Community members and maintainers show new features, integrations, and real-world use cases |
+| **Open Q&A** | Bring your questions about Cadence architecture, operations, SDKs, or migration |
+| **Maintainer updates** | What the core team is shipping next |
+| **New contributor onboarding** | Not sure how to start contributing? The meetup is a good first step |
+
+## Stay notified
+
 <Tabs>
-  <TabItem value="slack" label="Slack" default>
+  <TabItem value="email" label="Email" default>
+    Use the subscribe form above to receive announcements directly in your inbox via the CNCF Cadence Community mailing list.
+  </TabItem>
+  <TabItem value="slack" label="Slack">
     Join the [**#cadence-users** channel on CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf): meetup announcements are posted there first.
   </TabItem>
   <TabItem value="github" label="GitHub">
     Watch the [cadence-workflow GitHub org](https://github.com/cadence-workflow) for event announcements.
   </TabItem>
-  <TabItem value="email" label="Email">
-    Use the subscribe form above to receive announcements directly in your inbox.
-  </TabItem>
 </Tabs>
-
-## What to expect
-
-| Session segment | Description |
-|---|---|
-| **Demos** | Community members and maintainers share new features, integrations, and real-world use cases |
-| **Open Q&A** | Bring your questions about Cadence architecture, operations, SDKs, or migration |
-| **Maintainer updates** | What the core team is working on and what is coming next |
-| **New contributor onboarding** | Not sure how to start contributing? The meetup is a good first step |
 
 ## Past sessions
 
-Past meetup recordings are published on the [Cadence YouTube channel](https://www.youtube.com/@cadenceworkflow). Recent highlights:
+Recordings are published on the [Cadence YouTube channel](https://www.youtube.com/@cadenceworkflow) after each session. Recent highlights:
 
 - [Cadence in 2025: Year in Review](https://www.youtube.com/watch?v=UmCFfEpAqNg)
 - [Cadence at Uber: Scale Overview](https://www.youtube.com/watch?v=-qj_Lb_basY)

--- a/community/meetup.mdx
+++ b/community/meetup.mdx
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Community Meetups
-description: Join the Cadence community meetup, a recurring gathering for Cadence users and contributors to share demos, ask questions, and connect with maintainers.
+description: Join the Cadence community meetup — a recurring gathering for Cadence users and contributors to share demos, ask questions, and connect with maintainers.
 keywords:
   - cadence meetup
   - cadence community meetup
@@ -13,29 +13,50 @@ keywords:
 permalink: /community/meetup
 ---
 
+import MailingListSignup from '@site/src/components/MailingListSignup';
+
 # Community Meetups
 
 The Cadence community meetup is a recurring gathering for users, contributors, and maintainers. Each session includes demos, open Q&A, and updates from the core team.
 
 Whether you are evaluating Cadence, running it in production, or contributing to the project, the meetup is the fastest way to get answers, see what others are building, and connect directly with maintainers.
 
+<MailingListSignup
+  headline="Stay updated on Cadence"
+  tagline="Subscribe to get meetup announcements, release notes, and community updates."
+/>
+
 ## Upcoming meetup
 
-Details for the next session will be posted here. To get notified:
+Details for the next session will be posted here. To get notified first:
 
-- Join the [**#cadence-users** channel on CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf); meetup announcements are posted there first
-- Watch the [cadence-workflow GitHub org](https://github.com/cadence-workflow) for event announcements
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+  <TabItem value="slack" label="Slack" default>
+    Join the [**#cadence-users** channel on CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) — meetup announcements are posted there first.
+  </TabItem>
+  <TabItem value="github" label="GitHub">
+    Watch the [cadence-workflow GitHub org](https://github.com/cadence-workflow) for event announcements.
+  </TabItem>
+  <TabItem value="email" label="Email">
+    Use the subscribe form above to receive announcements directly in your inbox.
+  </TabItem>
+</Tabs>
 
 ## What to expect
 
-- **Demos**: community members and maintainers share new features, integrations, and real-world use cases
-- **Open Q&A**: bring your questions about Cadence architecture, operations, SDKs, or migration
-- **Maintainer updates**: what the core team is working on and what is coming next
-- **New contributor onboarding**: not sure how to start contributing? The meetup is a good first step
+| Session segment | Description |
+|---|---|
+| **Demos** | Community members and maintainers share new features, integrations, and real-world use cases |
+| **Open Q&A** | Bring your questions about Cadence architecture, operations, SDKs, or migration |
+| **Maintainer updates** | What the core team is working on and what is coming next |
+| **New contributor onboarding** | Not sure how to start contributing? The meetup is a good first step |
 
 ## Past sessions
 
-Past meetup recordings are published on the [Cadence YouTube channel](https://www.youtube.com/@cadenceworkflow). A few recent highlights:
+Past meetup recordings are published on the [Cadence YouTube channel](https://www.youtube.com/@cadenceworkflow). Recent highlights:
 
 - [Cadence in 2025: Year in Review](https://www.youtube.com/watch?v=UmCFfEpAqNg)
 - [Cadence at Uber: Scale Overview](https://www.youtube.com/watch?v=-qj_Lb_basY)

--- a/community/meetup.mdx
+++ b/community/meetup.mdx
@@ -29,6 +29,7 @@ We're bringing back regular Cadence developer meetups, starting in the **Bay Are
 
 <MailingListSignup
   id="stay-updated-on-cadence"
+  badge="🗓 August 2026 · Bay Area"
   headline="Get notified for the next meetup"
   tagline="Subscribe to the CNCF Cadence Community list and be the first to hear when the date drops."
 />

--- a/community/meetup.mdx
+++ b/community/meetup.mdx
@@ -14,8 +14,6 @@ permalink: /community/meetup
 ---
 
 import MailingListSignup from '@site/src/components/MailingListSignup';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Community Meetups
 
@@ -48,17 +46,36 @@ Subscribe below to be the first to know when the next session is scheduled. Past
 
 ## Stay notified
 
-<Tabs>
-  <TabItem value="email" label="Email" default>
-    Use the subscribe form above to receive announcements directly in your inbox via the CNCF Cadence Community mailing list.
-  </TabItem>
-  <TabItem value="slack" label="Slack">
-    Join the [**#cadence-users** channel on CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf): meetup announcements are posted there first.
-  </TabItem>
-  <TabItem value="github" label="GitHub">
-    Watch the [cadence-workflow GitHub org](https://github.com/cadence-workflow) for event announcements.
-  </TabItem>
-</Tabs>
+<div style={{display:'grid', gridTemplateColumns:'repeat(auto-fit, minmax(210px, 1fr))', gap:'1rem', margin:'1.5rem 0 2rem'}}>
+
+  <div className="card" style={{padding:'1.25rem'}}>
+    <div style={{fontSize:'1.5rem', marginBottom:'0.5rem'}}>📧</div>
+    <strong>Email</strong>
+    <p style={{fontSize:'0.875rem', color:'var(--ifm-color-emphasis-700)', margin:'0.4rem 0 0.8rem', lineHeight:1.5}}>
+      Get meetup announcements in your inbox via the CNCF Cadence Community mailing list.
+    </p>
+    <a href="#stay-updated-on-cadence" className="button button--primary button--sm">Subscribe above ↑</a>
+  </div>
+
+  <div className="card" style={{padding:'1.25rem'}}>
+    <div style={{fontSize:'1.5rem', marginBottom:'0.5rem'}}>💬</div>
+    <strong>Slack</strong>
+    <p style={{fontSize:'0.875rem', color:'var(--ifm-color-emphasis-700)', margin:'0.4rem 0 0.8rem', lineHeight:1.5}}>
+      Join <strong>#cadence-users</strong> on CNCF Slack — announcements land here first.
+    </p>
+    <a href="https://communityinviter.com/apps/cloud-native/cncf" target="_blank" rel="noopener noreferrer" className="button button--secondary button--sm">Join Slack ↗</a>
+  </div>
+
+  <div className="card" style={{padding:'1.25rem'}}>
+    <div style={{fontSize:'1.5rem', marginBottom:'0.5rem'}}>🐙</div>
+    <strong>GitHub</strong>
+    <p style={{fontSize:'0.875rem', color:'var(--ifm-color-emphasis-700)', margin:'0.4rem 0 0.8rem', lineHeight:1.5}}>
+      Watch the cadence-workflow GitHub org for event and release announcements.
+    </p>
+    <a href="https://github.com/cadence-workflow" target="_blank" rel="noopener noreferrer" className="button button--secondary button--sm">Watch on GitHub ↗</a>
+  </div>
+
+</div>
 
 ## Past sessions
 
@@ -69,12 +86,44 @@ Recordings are published on the [Cadence YouTube channel](https://www.youtube.co
 
 ## Get involved
 
-| Channel | Link |
-|---|---|
-| CNCF Slack `#cadence-users` | [Join](https://communityinviter.com/apps/cloud-native/cncf) |
-| Discord | [discord.gg/ynvjm2Et5](https://discord.gg/ynvjm2Et5) |
-| GitHub Discussions | [cadence-workflow/cadence/discussions](https://github.com/cadence-workflow/cadence/discussions) |
-| Stack Overflow | [`cadence-workflow` tag](https://stackoverflow.com/questions/tagged/cadence-workflow) |
-| Reddit | [r/cadenceworkflow](https://www.reddit.com/r/cadenceworkflow/) |
+<div style={{display:'grid', gridTemplateColumns:'repeat(auto-fill, minmax(185px, 1fr))', gap:'1rem', margin:'1.5rem 0'}}>
+
+  <a href="https://communityinviter.com/apps/cloud-native/cncf" target="_blank" rel="noopener noreferrer" className="card" style={{padding:'1rem', textDecoration:'none', color:'inherit', display:'block'}}>
+    <div style={{fontSize:'1.25rem', marginBottom:'0.35rem'}}>💬</div>
+    <strong style={{display:'block', marginBottom:'0.2rem'}}>CNCF Slack</strong>
+    <span style={{fontSize:'0.8rem', color:'var(--ifm-color-emphasis-600)'}}>#cadence-users</span>
+  </a>
+
+  <a href="https://discord.gg/ynvjm2Et5" target="_blank" rel="noopener noreferrer" className="card" style={{padding:'1rem', textDecoration:'none', color:'inherit', display:'block'}}>
+    <div style={{fontSize:'1.25rem', marginBottom:'0.35rem'}}>🎮</div>
+    <strong style={{display:'block', marginBottom:'0.2rem'}}>Discord</strong>
+    <span style={{fontSize:'0.8rem', color:'var(--ifm-color-emphasis-600)'}}>discord.gg/ynvjm2Et5</span>
+  </a>
+
+  <a href="https://github.com/cadence-workflow/cadence/discussions" target="_blank" rel="noopener noreferrer" className="card" style={{padding:'1rem', textDecoration:'none', color:'inherit', display:'block'}}>
+    <div style={{fontSize:'1.25rem', marginBottom:'0.35rem'}}>🐙</div>
+    <strong style={{display:'block', marginBottom:'0.2rem'}}>GitHub Discussions</strong>
+    <span style={{fontSize:'0.8rem', color:'var(--ifm-color-emphasis-600)'}}>cadence-workflow/cadence</span>
+  </a>
+
+  <a href="https://stackoverflow.com/questions/tagged/cadence-workflow" target="_blank" rel="noopener noreferrer" className="card" style={{padding:'1rem', textDecoration:'none', color:'inherit', display:'block'}}>
+    <div style={{fontSize:'1.25rem', marginBottom:'0.35rem'}}>📚</div>
+    <strong style={{display:'block', marginBottom:'0.2rem'}}>Stack Overflow</strong>
+    <span style={{fontSize:'0.8rem', color:'var(--ifm-color-emphasis-600)'}}>cadence-workflow tag</span>
+  </a>
+
+  <a href="https://www.reddit.com/r/cadenceworkflow/" target="_blank" rel="noopener noreferrer" className="card" style={{padding:'1rem', textDecoration:'none', color:'inherit', display:'block'}}>
+    <div style={{fontSize:'1.25rem', marginBottom:'0.35rem'}}>🔗</div>
+    <strong style={{display:'block', marginBottom:'0.2rem'}}>Reddit</strong>
+    <span style={{fontSize:'0.8rem', color:'var(--ifm-color-emphasis-600)'}}>r/cadenceworkflow</span>
+  </a>
+
+  <a href="https://www.linkedin.com/company/cadenceworkflow" target="_blank" rel="noopener noreferrer" className="card" style={{padding:'1rem', textDecoration:'none', color:'inherit', display:'block'}}>
+    <div style={{fontSize:'1.25rem', marginBottom:'0.35rem'}}>💼</div>
+    <strong style={{display:'block', marginBottom:'0.2rem'}}>LinkedIn</strong>
+    <span style={{fontSize:'0.8rem', color:'var(--ifm-color-emphasis-600)'}}>/cadenceworkflow</span>
+  </a>
+
+</div>
 
 Want to present at a future meetup or propose a topic? Reach out in the `#cadence-users` Slack channel or open a [GitHub Discussion](https://github.com/cadence-workflow/cadence/discussions).

--- a/community/meetup.mdx
+++ b/community/meetup.mdx
@@ -22,6 +22,7 @@ The Cadence community meetup is a recurring gathering for users, contributors, a
 Whether you are evaluating Cadence, running it in production, or contributing to the project, the meetup is the fastest way to get answers, see what others are building, and connect directly with maintainers.
 
 <MailingListSignup
+  id="stay-updated-on-cadence"
   headline="Stay updated on Cadence"
   tagline="Subscribe to get meetup announcements, release notes, and community updates."
 />

--- a/community/meetup.mdx
+++ b/community/meetup.mdx
@@ -24,7 +24,7 @@ Whether you're evaluating Cadence, running it in production, or ready to contrib
 ## Next session
 
 :::info Restarting Cadence developer meetups
-We are planning to restart regular Cadence developer meetups, kicking off in the **Bay Area**. Details are being finalized — subscribe below to be the first to know when the date and location are set. Past recordings are on [YouTube](https://www.youtube.com/@cadenceworkflow) while you wait.
+We're bringing back regular Cadence developer meetups, starting in the **Bay Area** in **August**. Subscribe below to get the date, location, and agenda when they're confirmed. Past recordings are on [YouTube](https://www.youtube.com/@cadenceworkflow) while you wait.
 :::
 
 <MailingListSignup

--- a/community/meetup.mdx
+++ b/community/meetup.mdx
@@ -23,10 +23,8 @@ Whether you're evaluating Cadence, running it in production, or ready to contrib
 
 ## Next session
 
-:::info Upcoming meetup
-**Date:** To be announced.
-
-Subscribe below to be the first to know when the next session is scheduled. Past recordings are on [YouTube](https://www.youtube.com/@cadenceworkflow) while you wait.
+:::info Restarting Cadence developer meetups
+We are planning to restart regular Cadence developer meetups, kicking off in the **Bay Area**. Details are being finalized — subscribe below to be the first to know when the date and location are set. Past recordings are on [YouTube](https://www.youtube.com/@cadenceworkflow) while you wait.
 :::
 
 <MailingListSignup
@@ -87,12 +85,6 @@ Recordings are published on the [Cadence YouTube channel](https://www.youtube.co
 ## Get involved
 
 <div style={{display:'grid', gridTemplateColumns:'repeat(auto-fill, minmax(185px, 1fr))', gap:'1rem', margin:'1.5rem 0'}}>
-
-  <a href="https://communityinviter.com/apps/cloud-native/cncf" target="_blank" rel="noopener noreferrer" className="card" style={{padding:'1rem', textDecoration:'none', color:'inherit', display:'block'}}>
-    <div style={{fontSize:'1.25rem', marginBottom:'0.35rem'}}>💬</div>
-    <strong style={{display:'block', marginBottom:'0.2rem'}}>CNCF Slack</strong>
-    <span style={{fontSize:'0.8rem', color:'var(--ifm-color-emphasis-600)'}}>#cadence-users</span>
-  </a>
 
   <a href="https://discord.gg/ynvjm2Et5" target="_blank" rel="noopener noreferrer" className="card" style={{padding:'1rem', textDecoration:'none', color:'inherit', display:'block'}}>
     <div style={{fontSize:'1.25rem', marginBottom:'0.35rem'}}>🎮</div>

--- a/docs/02-use-cases/01-periodic-execution.md
+++ b/docs/02-use-cases/01-periodic-execution.md
@@ -29,6 +29,6 @@ There are many real-world examples of Cadence periodic executions. Such as the f
 
 Cadence offers two approaches:
 
-**[Schedules](/docs/concepts/schedules)** — the recommended approach for new code. A Schedule is a first-class server-side object that you create, pause, update, and backfill independently of your workflow. It supports overlap policies, catch-up windows, and full observability without modifying your workflow code. Use the `ScheduleClient` in the Go SDK to manage schedules programmatically.
+**[Schedules](/docs/concepts/schedules)**: the recommended approach for new code. A Schedule is a first-class server-side object that you create, pause, update, and backfill independently of your workflow. It supports overlap policies, catch-up windows, and full observability without modifying your workflow code. Use the `ScheduleClient` in the Go SDK to manage schedules programmatically.
 
-**[Distributed Cron](/docs/go-client/distributed-cron)** — the older approach using `CronSchedule` on `StartWorkflowOptions`. Simpler to set up but less flexible: you cannot pause, update, or backfill a cron workflow without restarting it, and overlap is always skip-new.
+**[Distributed Cron](/docs/go-client/distributed-cron)**: the older approach using `CronSchedule` on `StartWorkflowOptions`. Simpler to set up but less flexible: you cannot pause, update, or backfill a cron workflow without restarting it, and overlap is always skip-new.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -90,10 +90,12 @@ const config: Config = {
         googleTagManager: {
           containerId: 'G-W63QD8QE6E',
         },
-        gtag: {
-          trackingID: 'G-W63QD8QE6E',
-          anonymizeIP: true,
-        },
+        ...(process.env.NODE_ENV === 'production' && {
+          gtag: {
+            trackingID: 'G-W63QD8QE6E',
+            anonymizeIP: true,
+          },
+        }),
         sitemap: {
           changefreq: 'weekly',
           createSitemapItems: async (params) => {

--- a/lychee.toml
+++ b/lychee.toml
@@ -13,7 +13,7 @@ max_concurrency = 16
 # from external sites is not reported as link rot.
 accept = [200, 203, 206, 429]
 
-# Skip URLs that routinely 403 bots regardless of how politely we crawl.
+# Skip URLs that routinely 403/406 bots regardless of how politely we crawl.
 exclude = [
   "^http(s)?://localhost",
   "^http(s)?://127\\.0\\.0\\.1",
@@ -22,6 +22,7 @@ exclude = [
   "slack\\.com",
   "reddit\\.com",
   "lf\\.biz",
+  "uber\\.com",
 ]
 
 # Never traverse these paths when expanding inputs.

--- a/src/components/MailingListSignup/index.tsx
+++ b/src/components/MailingListSignup/index.tsx
@@ -9,12 +9,14 @@ interface Props {
   id?: string;
   headline?: string;
   tagline?: string;
+  badge?: string;
 }
 
 export default function MailingListSignup({
   id,
   headline = 'Stay in the loop',
   tagline = 'Get meetup announcements, release notes, and community updates delivered to your inbox.',
+  badge,
 }: Props) {
   const [email, setEmail] = useState('');
   const [state, setState] = useState<State>('idle');
@@ -102,8 +104,8 @@ export default function MailingListSignup({
   return (
     <div className={styles.banner} id={id}>
       <div className={styles.inner}>
-        <h2 className={styles.headline}>{headline}</h2>
-        <p className={styles.tagline}>{tagline}</p>
+        {badge && <div className={styles.badge}>{badge}</div>}
+        <h2 className={styles.headline}>{headline}</h2>        <p className={styles.tagline}>{tagline}</p>
 
         <form className={styles.form} onSubmit={handleSubmit}>
           <div className={styles.inputRow}>
@@ -120,7 +122,7 @@ export default function MailingListSignup({
               onChange={(e) => setEmail(e.target.value)}
               required
             />
-            <button type="submit" className={styles.button} disabled={!email}>
+            <button type="submit" className={`${styles.button} ${email ? styles.buttonReady : ''}`} disabled={!email}>
               Subscribe →
             </button>
           </div>

--- a/src/components/MailingListSignup/index.tsx
+++ b/src/components/MailingListSignup/index.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import styles from './styles.module.css';
+
+/**
+ * Formspree form ID.
+ * To activate: go to https://formspree.io, create a form named
+ * "Cadence Community Mailing List", and replace this placeholder with
+ * your form ID (e.g. "xpwdkrqb").
+ */
+const FORMSPREE_FORM_ID = 'YOUR_FORM_ID';
+
+type State = 'idle' | 'submitting' | 'success' | 'error';
+
+interface Props {
+  /** Headline shown above the input row. */
+  headline?: string;
+  /** Supporting copy shown below the headline. */
+  tagline?: string;
+}
+
+export default function MailingListSignup({
+  headline = 'Stay in the loop',
+  tagline = 'Get meetup announcements, release notes, and community updates delivered to your inbox.',
+}: Props) {
+  const [email, setEmail] = useState('');
+  const [state, setState] = useState<State>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!email) return;
+
+    setState('submitting');
+    setErrorMsg('');
+
+    try {
+      const res = await fetch(`https://formspree.io/f/${FORMSPREE_FORM_ID}`, {
+        method: 'POST',
+        headers: { Accept: 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+
+      if (res.ok) {
+        setState('success');
+        setEmail('');
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setErrorMsg(
+          (data as { error?: string }).error ||
+            'Something went wrong. Please try again.',
+        );
+        setState('error');
+      }
+    } catch {
+      setErrorMsg('Network error. Please check your connection and try again.');
+      setState('error');
+    }
+  }
+
+  if (state === 'success') {
+    return (
+      <div className={styles.banner}>
+        <div className={styles.inner}>
+          <div className={styles.successIcon} aria-hidden="true">✓</div>
+          <p className={styles.successHeadline}>You&apos;re on the list!</p>
+          <p className={styles.successBody}>
+            We&apos;ll send you meetup announcements and community updates.
+            See you at the next session.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.banner}>
+      <div className={styles.inner}>
+        <h2 className={styles.headline}>{headline}</h2>
+        <p className={styles.tagline}>{tagline}</p>
+
+        <form className={styles.form} onSubmit={handleSubmit} noValidate>
+          <div className={styles.inputRow}>
+            <label htmlFor="mailing-list-email" className={styles.srOnly}>
+              Email address
+            </label>
+            <input
+              id="mailing-list-email"
+              type="email"
+              className={styles.input}
+              placeholder="you@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={state === 'submitting'}
+              aria-describedby={state === 'error' ? 'mailing-list-error' : undefined}
+            />
+            <button
+              type="submit"
+              className={styles.button}
+              disabled={state === 'submitting' || !email}
+            >
+              {state === 'submitting' ? (
+                <span className={styles.spinner} aria-hidden="true" />
+              ) : null}
+              {state === 'submitting' ? 'Subscribing…' : 'Subscribe'}
+            </button>
+          </div>
+
+          {state === 'error' && (
+            <p id="mailing-list-error" className={styles.errorMsg} role="alert">
+              {errorMsg}
+            </p>
+          )}
+        </form>
+
+        <p className={styles.privacyNote}>
+          No spam. Unsubscribe any time.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MailingListSignup/index.tsx
+++ b/src/components/MailingListSignup/index.tsx
@@ -1,17 +1,13 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import styles from './styles.module.css';
 
 const SUBSCRIBE_EMAIL = 'cncf-cadence-community+subscribe@lists.cncf.io';
-const SUBSCRIBE_MAILTO = `mailto:${SUBSCRIBE_EMAIL}`;
 
 type State = 'idle' | 'opened';
 
 interface Props {
-  /** HTML id placed on the banner wrapper, enabling deep-link anchors. */
   id?: string;
-  /** Headline shown above the CTA. */
   headline?: string;
-  /** Supporting copy shown below the headline. */
   tagline?: string;
 }
 
@@ -20,10 +16,19 @@ export default function MailingListSignup({
   headline = 'Stay in the loop',
   tagline = 'Get meetup announcements, release notes, and community updates delivered to your inbox.',
 }: Props) {
+  const [email, setEmail] = useState('');
   const [state, setState] = useState<State>('idle');
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  function handleSubscribe() {
-    window.open(SUBSCRIBE_MAILTO, '_blank');
+  useEffect(() => {
+    const t = setTimeout(() => inputRef.current?.focus(), 400);
+    return () => clearTimeout(t);
+  }, []);
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!email) return;
+    window.open(`mailto:${SUBSCRIBE_EMAIL}`, '_blank');
     setState('opened');
   }
 
@@ -31,16 +36,14 @@ export default function MailingListSignup({
     return (
       <div className={styles.banner} id={id}>
         <div className={styles.inner}>
-          <div className={styles.successIcon} aria-hidden="true">✓</div>
+          <div className={styles.successIcon} aria-hidden="true">✉</div>
           <p className={styles.successHeadline}>Check your email client</p>
           <p className={styles.successBody}>
-            Send the pre-addressed email that just opened. Groups.io will reply
-            with a confirmation link — click it to complete your subscription.
+            Send the pre-addressed email that just opened
+            {email ? <> from <strong className={styles.emailHighlight}>{email}</strong></> : ''}.
+            Groups.io will send a confirmation link — click it to complete your subscription.
           </p>
-          <button
-            className={styles.buttonSecondary}
-            onClick={() => setState('idle')}
-          >
+          <button className={styles.buttonSecondary} onClick={() => setState('idle')}>
             Back
           </button>
         </div>
@@ -54,15 +57,26 @@ export default function MailingListSignup({
         <h2 className={styles.headline}>{headline}</h2>
         <p className={styles.tagline}>{tagline}</p>
 
-        <div className={styles.ctaRow}>
-          <button
-            type="button"
-            className={styles.button}
-            onClick={handleSubscribe}
-          >
-            Subscribe via email
-          </button>
-        </div>
+        <form className={styles.form} onSubmit={handleSubmit}>
+          <div className={styles.inputRow}>
+            <label htmlFor="mailing-list-email" className={styles.srOnly}>
+              Email address
+            </label>
+            <input
+              ref={inputRef}
+              id="mailing-list-email"
+              type="email"
+              className={styles.input}
+              placeholder="you@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+            <button type="submit" className={styles.button} disabled={!email}>
+              Subscribe
+            </button>
+          </div>
+        </form>
 
         <p className={styles.privacyNote}>
           Joins the CNCF Cadence Community mailing list. Unsubscribe any time.

--- a/src/components/MailingListSignup/index.tsx
+++ b/src/components/MailingListSignup/index.tsx
@@ -12,6 +12,8 @@ const FORMSPREE_FORM_ID = 'YOUR_FORM_ID';
 type State = 'idle' | 'submitting' | 'success' | 'error';
 
 interface Props {
+  /** HTML id placed on the banner wrapper, enabling deep-link anchors. */
+  id?: string;
   /** Headline shown above the input row. */
   headline?: string;
   /** Supporting copy shown below the headline. */
@@ -19,6 +21,7 @@ interface Props {
 }
 
 export default function MailingListSignup({
+  id,
   headline = 'Stay in the loop',
   tagline = 'Get meetup announcements, release notes, and community updates delivered to your inbox.',
 }: Props) {
@@ -26,9 +29,14 @@ export default function MailingListSignup({
   const [state, setState] = useState<State>('idle');
   const [errorMsg, setErrorMsg] = useState('');
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (!email) return;
+    if (!e.currentTarget.checkValidity()) {
+      setErrorMsg('Please enter a valid email address.');
+      setState('error');
+      return;
+    }
 
     setState('submitting');
     setErrorMsg('');
@@ -59,7 +67,7 @@ export default function MailingListSignup({
 
   if (state === 'success') {
     return (
-      <div className={styles.banner}>
+      <div className={styles.banner} id={id}>
         <div className={styles.inner}>
           <div className={styles.successIcon} aria-hidden="true">✓</div>
           <p className={styles.successHeadline}>You&apos;re on the list!</p>
@@ -73,12 +81,12 @@ export default function MailingListSignup({
   }
 
   return (
-    <div className={styles.banner}>
+    <div className={styles.banner} id={id}>
       <div className={styles.inner}>
         <h2 className={styles.headline}>{headline}</h2>
         <p className={styles.tagline}>{tagline}</p>
 
-        <form className={styles.form} onSubmit={handleSubmit} noValidate>
+        <form className={styles.form} onSubmit={handleSubmit}>
           <div className={styles.inputRow}>
             <label htmlFor="mailing-list-email" className={styles.srOnly}>
               Email address

--- a/src/components/MailingListSignup/index.tsx
+++ b/src/components/MailingListSignup/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import styles from './styles.module.css';
 
-const SUBSCRIBE_EMAIL = 'cncf-cadence-community+subscribe@lists.cncf.io';
+const JOIN_BASE = 'https://lists.cncf.io/g/cncf-cadence-community/join';
 
 type State = 'idle' | 'opened';
 
@@ -28,7 +28,8 @@ export default function MailingListSignup({
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (!email) return;
-    window.open(`mailto:${SUBSCRIBE_EMAIL}`, '_blank');
+    const url = `${JOIN_BASE}?email=${encodeURIComponent(email)}`;
+    window.open(url, '_blank', 'noopener,noreferrer');
     setState('opened');
   }
 
@@ -36,14 +37,24 @@ export default function MailingListSignup({
     return (
       <div className={styles.banner} id={id}>
         <div className={styles.inner}>
-          <div className={styles.successIcon} aria-hidden="true">✉</div>
-          <p className={styles.successHeadline}>Check your email client</p>
+          <div className={styles.successIcon} aria-hidden="true">✅</div>
+          <p className={styles.successHeadline}>One more click</p>
           <p className={styles.successBody}>
-            Send the pre-addressed email that just opened
-            {email ? <> from <strong className={styles.emailHighlight}>{email}</strong></> : ''}.
-            Groups.io will send a confirmation link — click it to complete your subscription.
+            The CNCF groups.io page just opened with{' '}
+            {email ? <strong className={styles.emailHighlight}>{email}</strong> : 'your email'}{' '}
+            pre-filled. Click <strong>"Confirm Email Address"</strong> there and you're done —
+            groups.io will send you a confirmation.
           </p>
-          <button className={styles.buttonSecondary} onClick={() => setState('idle')}>
+          <a
+            href={`${JOIN_BASE}?email=${encodeURIComponent(email)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.button}
+            style={{ display: 'inline-flex', textDecoration: 'none', marginTop: '0.75rem' }}
+          >
+            Open again ↗
+          </a>
+          <button className={styles.buttonSecondary} onClick={() => { setEmail(''); setState('idle'); }}>
             Back
           </button>
         </div>
@@ -73,7 +84,7 @@ export default function MailingListSignup({
               required
             />
             <button type="submit" className={styles.button} disabled={!email}>
-              Subscribe
+              Subscribe →
             </button>
           </div>
         </form>

--- a/src/components/MailingListSignup/index.tsx
+++ b/src/components/MailingListSignup/index.tsx
@@ -29,8 +29,9 @@ export default function MailingListSignup({
     e.preventDefault();
     if (!email) return;
     const url = `${JOIN_BASE}?email=${encodeURIComponent(email)}`;
-    const win = window.open(url, '_blank', 'noopener,noreferrer');
+    const win = window.open(url, '_blank');
     if (win) {
+      win.opener = null; // retain noopener protection while keeping the reference
       setState('opened');
     } else {
       // Popup was blocked — show a direct link instead of the confirmation view

--- a/src/components/MailingListSignup/index.tsx
+++ b/src/components/MailingListSignup/index.tsx
@@ -21,9 +21,12 @@ export default function MailingListSignup({
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    const t = setTimeout(() => inputRef.current?.focus(), 400);
-    return () => clearTimeout(t);
-  }, []);
+    // Only auto-focus when the user arrives directly via the anchor link
+    if (id && typeof window !== 'undefined' && window.location.hash === `#${id}`) {
+      const t = setTimeout(() => inputRef.current?.focus(), 400);
+      return () => clearTimeout(t);
+    }
+  }, [id]);
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();

--- a/src/components/MailingListSignup/index.tsx
+++ b/src/components/MailingListSignup/index.tsx
@@ -3,7 +3,7 @@ import styles from './styles.module.css';
 
 const JOIN_BASE = 'https://lists.cncf.io/g/cncf-cadence-community/join';
 
-type State = 'idle' | 'opened';
+type State = 'idle' | 'opened' | 'blocked';
 
 interface Props {
   id?: string;
@@ -29,8 +29,41 @@ export default function MailingListSignup({
     e.preventDefault();
     if (!email) return;
     const url = `${JOIN_BASE}?email=${encodeURIComponent(email)}`;
-    window.open(url, '_blank', 'noopener,noreferrer');
-    setState('opened');
+    const win = window.open(url, '_blank', 'noopener,noreferrer');
+    if (win) {
+      setState('opened');
+    } else {
+      // Popup was blocked — show a direct link instead of the confirmation view
+      setState('blocked');
+    }
+  }
+
+  if (state === 'blocked') {
+    const url = `${JOIN_BASE}?email=${encodeURIComponent(email)}`;
+    return (
+      <div className={styles.banner} id={id}>
+        <div className={styles.inner}>
+          <div className={styles.successIcon} aria-hidden="true">🚫</div>
+          <p className={styles.successHeadline}>Popup blocked</p>
+          <p className={styles.successBody}>
+            Your browser blocked the new tab. Click the link below to open the groups.io page
+            {email ? <> with <strong className={styles.emailHighlight}>{email}</strong> pre-filled</> : ''}.
+          </p>
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.button}
+            style={{ display: 'inline-flex', textDecoration: 'none', marginTop: '0.75rem' }}
+          >
+            Open groups.io ↗
+          </a>
+          <button className={styles.buttonSecondary} onClick={() => setState('idle')}>
+            Back
+          </button>
+        </div>
+      </div>
+    );
   }
 
   if (state === 'opened') {

--- a/src/components/MailingListSignup/index.tsx
+++ b/src/components/MailingListSignup/index.tsx
@@ -1,20 +1,15 @@
 import React, { useState } from 'react';
 import styles from './styles.module.css';
 
-/**
- * Formspree form ID.
- * To activate: go to https://formspree.io, create a form named
- * "Cadence Community Mailing List", and replace this placeholder with
- * your form ID (e.g. "xpwdkrqb").
- */
-const FORMSPREE_FORM_ID = 'xojooqjk';
+const SUBSCRIBE_EMAIL = 'cncf-cadence-community+subscribe@lists.cncf.io';
+const SUBSCRIBE_MAILTO = `mailto:${SUBSCRIBE_EMAIL}`;
 
-type State = 'idle' | 'submitting' | 'success' | 'error';
+type State = 'idle' | 'opened';
 
 interface Props {
   /** HTML id placed on the banner wrapper, enabling deep-link anchors. */
   id?: string;
-  /** Headline shown above the input row. */
+  /** Headline shown above the CTA. */
   headline?: string;
   /** Supporting copy shown below the headline. */
   tagline?: string;
@@ -25,56 +20,29 @@ export default function MailingListSignup({
   headline = 'Stay in the loop',
   tagline = 'Get meetup announcements, release notes, and community updates delivered to your inbox.',
 }: Props) {
-  const [email, setEmail] = useState('');
   const [state, setState] = useState<State>('idle');
-  const [errorMsg, setErrorMsg] = useState('');
 
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    if (!email) return;
-    if (!e.currentTarget.checkValidity()) {
-      setErrorMsg('Please enter a valid email address.');
-      setState('error');
-      return;
-    }
-
-    setState('submitting');
-    setErrorMsg('');
-
-    try {
-      const res = await fetch(`https://formspree.io/f/${FORMSPREE_FORM_ID}`, {
-        method: 'POST',
-        headers: { Accept: 'application/json' },
-        body: JSON.stringify({ email }),
-      });
-
-      if (res.ok) {
-        setState('success');
-        setEmail('');
-      } else {
-        const data = await res.json().catch(() => ({}));
-        setErrorMsg(
-          (data as { error?: string }).error ||
-            'Something went wrong. Please try again.',
-        );
-        setState('error');
-      }
-    } catch {
-      setErrorMsg('Network error. Please check your connection and try again.');
-      setState('error');
-    }
+  function handleSubscribe() {
+    window.open(SUBSCRIBE_MAILTO, '_blank');
+    setState('opened');
   }
 
-  if (state === 'success') {
+  if (state === 'opened') {
     return (
       <div className={styles.banner} id={id}>
         <div className={styles.inner}>
           <div className={styles.successIcon} aria-hidden="true">✓</div>
-          <p className={styles.successHeadline}>You&apos;re on the list!</p>
+          <p className={styles.successHeadline}>Check your email client</p>
           <p className={styles.successBody}>
-            We&apos;ll send you meetup announcements and community updates.
-            See you at the next session.
+            Send the pre-addressed email that just opened. Groups.io will reply
+            with a confirmation link — click it to complete your subscription.
           </p>
+          <button
+            className={styles.buttonSecondary}
+            onClick={() => setState('idle')}
+          >
+            Back
+          </button>
         </div>
       </div>
     );
@@ -86,43 +54,18 @@ export default function MailingListSignup({
         <h2 className={styles.headline}>{headline}</h2>
         <p className={styles.tagline}>{tagline}</p>
 
-        <form className={styles.form} onSubmit={handleSubmit}>
-          <div className={styles.inputRow}>
-            <label htmlFor="mailing-list-email" className={styles.srOnly}>
-              Email address
-            </label>
-            <input
-              id="mailing-list-email"
-              type="email"
-              className={styles.input}
-              placeholder="you@example.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              disabled={state === 'submitting'}
-              aria-describedby={state === 'error' ? 'mailing-list-error' : undefined}
-            />
-            <button
-              type="submit"
-              className={styles.button}
-              disabled={state === 'submitting' || !email}
-            >
-              {state === 'submitting' ? (
-                <span className={styles.spinner} aria-hidden="true" />
-              ) : null}
-              {state === 'submitting' ? 'Subscribing…' : 'Subscribe'}
-            </button>
-          </div>
-
-          {state === 'error' && (
-            <p id="mailing-list-error" className={styles.errorMsg} role="alert">
-              {errorMsg}
-            </p>
-          )}
-        </form>
+        <div className={styles.ctaRow}>
+          <button
+            type="button"
+            className={styles.button}
+            onClick={handleSubscribe}
+          >
+            Subscribe via email
+          </button>
+        </div>
 
         <p className={styles.privacyNote}>
-          No spam. Unsubscribe any time.
+          Joins the CNCF Cadence Community mailing list. Unsubscribe any time.
         </p>
       </div>
     </div>

--- a/src/components/MailingListSignup/index.tsx
+++ b/src/components/MailingListSignup/index.tsx
@@ -7,7 +7,7 @@ import styles from './styles.module.css';
  * "Cadence Community Mailing List", and replace this placeholder with
  * your form ID (e.g. "xpwdkrqb").
  */
-const FORMSPREE_FORM_ID = 'YOUR_FORM_ID';
+const FORMSPREE_FORM_ID = 'xojooqjk';
 
 type State = 'idle' | 'submitting' | 'success' | 'error';
 

--- a/src/components/MailingListSignup/styles.module.css
+++ b/src/components/MailingListSignup/styles.module.css
@@ -1,0 +1,187 @@
+/* Banner wrapper */
+.banner {
+  background: linear-gradient(135deg, #1a2b4a 0%, #2563eb 60%, #1e3a5f 100%);
+  border-radius: 1rem;
+  padding: 2.5rem 1.5rem;
+  margin: 2rem 0;
+  text-align: center;
+  box-shadow: 0 8px 32px rgba(37, 99, 235, 0.25);
+}
+
+.inner {
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+/* Headline + tagline */
+.headline {
+  color: #ffffff;
+  font-size: 1.6rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.02em;
+}
+
+.tagline {
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 1rem;
+  margin: 0 0 1.5rem;
+  line-height: 1.6;
+}
+
+/* Form */
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.inputRow {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+
+.input {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+  transition: border-color 0.2s, background 0.2s;
+  min-width: 0;
+}
+
+.input::placeholder {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.input:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.button {
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 700;
+  border: none;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #1a2b4a;
+  cursor: pointer;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: background 0.2s, transform 0.15s, opacity 0.2s;
+  flex-shrink: 0;
+}
+
+.button:hover:not(:disabled) {
+  background: #e0eaff;
+  transform: translateY(-1px);
+}
+
+.button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+  transform: none;
+}
+
+/* Spinner */
+.spinner {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid rgba(26, 43, 74, 0.3);
+  border-top-color: #1a2b4a;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Error */
+.errorMsg {
+  color: #fca5a5;
+  font-size: 0.875rem;
+  margin: 0;
+  text-align: left;
+}
+
+/* Privacy note */
+.privacyNote {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.8rem;
+  margin: 0.75rem 0 0;
+}
+
+/* Success state */
+.successIcon {
+  width: 3rem;
+  height: 3rem;
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  margin: 0 auto 1rem;
+  color: #ffffff;
+  line-height: 3rem;
+}
+
+.successHeadline {
+  color: #ffffff;
+  font-size: 1.4rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem;
+}
+
+.successBody {
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 1rem;
+  margin: 0;
+  line-height: 1.6;
+}
+
+/* Accessibility */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Responsive: stack on narrow screens */
+@media (max-width: 480px) {
+  .inputRow {
+    flex-direction: column;
+  }
+
+  .button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .headline {
+    font-size: 1.3rem;
+  }
+}

--- a/src/components/MailingListSignup/styles.module.css
+++ b/src/components/MailingListSignup/styles.module.css
@@ -65,14 +65,50 @@
 }
 
 /* Form / CTA row */
-.ctaRow {
+.form {
   display: flex;
-  justify-content: center;
-  margin-bottom: 0.25rem;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.inputRow {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+
+.input {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+  min-width: 0;
+  transition: border-color 0.2s, background 0.2s, box-shadow 0.2s;
+  animation: inputGlow 2s ease-in-out 0.6s 3 both;
+}
+
+.input::placeholder {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.input:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.15);
+  animation: none;
+}
+
+@keyframes inputGlow {
+  0%,  100% { border-color: rgba(255, 255, 255, 0.3); box-shadow: none; }
+  50%        { border-color: rgba(255, 255, 255, 0.75); box-shadow: 0 0 12px rgba(255,255,255,0.2); }
 }
 
 .button {
-  padding: 0.75rem 2rem;
+  padding: 0.75rem 1.5rem;
   font-size: 1rem;
   font-weight: 700;
   border: none;
@@ -84,12 +120,18 @@
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  flex-shrink: 0;
   transition: background 0.2s, transform 0.15s;
 }
 
-.button:hover {
+.button:hover:not(:disabled) {
   background: #e0eaff;
   transform: translateY(-1px);
+}
+
+.button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .buttonSecondary {
@@ -168,6 +210,12 @@
   font-size: 0.7rem;
 }
 
+/* Confirmed email highlight in success state */
+.emailHighlight {
+  color: #ffffff;
+  font-style: normal;
+}
+
 /* Accessibility */
 .srOnly {
   position: absolute;
@@ -181,8 +229,12 @@
   border: 0;
 }
 
-/* Responsive: full-width button on narrow screens */
+/* Responsive: stack on narrow screens */
 @media (max-width: 480px) {
+  .inputRow {
+    flex-direction: column;
+  }
+
   .button {
     width: 100%;
     justify-content: center;

--- a/src/components/MailingListSignup/styles.module.css
+++ b/src/components/MailingListSignup/styles.module.css
@@ -2,10 +2,10 @@
 .banner {
   background: linear-gradient(135deg, #1a2b4a 0%, #2563eb 55%, #1e40af 100%);
   border-radius: 1rem;
-  padding: 2.5rem 1.5rem;
+  padding: 2.75rem 1.75rem;
   margin: 2rem 0;
   text-align: center;
-  box-shadow: 0 8px 32px rgba(37, 99, 235, 0.3);
+  box-shadow: 0 8px 48px rgba(37, 99, 235, 0.45), 0 0 0 1px rgba(255,255,255,0.08);
   position: relative;
   overflow: hidden;
 }
@@ -48,10 +48,30 @@
   margin: 0 auto;
 }
 
+/* Event badge pill */
+.badge {
+  display: inline-block;
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: #ffffff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  margin-bottom: 0.85rem;
+  animation: badgeFadeIn 0.4s ease-out both;
+}
+
+@keyframes badgeFadeIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 /* Headline + tagline */
 .headline {
   color: #ffffff;
-  font-size: 1.6rem;
+  font-size: 1.8rem;
   font-weight: 800;
   margin: 0 0 0.5rem;
   letter-spacing: -0.02em;
@@ -132,6 +152,16 @@
 .button:disabled {
   opacity: 0.55;
   cursor: not-allowed;
+}
+
+/* Pulse the button once an email is typed */
+.buttonReady {
+  animation: buttonPulse 1.4s ease-in-out 0.3s 2 both;
+}
+
+@keyframes buttonPulse {
+  0%, 100% { box-shadow: none; }
+  50%       { box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.35); }
 }
 
 .buttonSecondary {

--- a/src/components/MailingListSignup/styles.module.css
+++ b/src/components/MailingListSignup/styles.module.css
@@ -64,48 +64,15 @@
   line-height: 1.6;
 }
 
-/* Form */
-.form {
+/* Form / CTA row */
+.ctaRow {
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.inputRow {
-  display: flex;
-  gap: 0.5rem;
-  align-items: stretch;
-}
-
-.input {
-  flex: 1;
-  padding: 0.75rem 1rem;
-  font-size: 1rem;
-  border: 2px solid rgba(255, 255, 255, 0.25);
-  border-radius: 0.5rem;
-  background: rgba(255, 255, 255, 0.12);
-  color: #ffffff;
-  transition: border-color 0.2s, background 0.2s;
-  min-width: 0;
-}
-
-.input::placeholder {
-  color: rgba(255, 255, 255, 0.5);
-}
-
-.input:focus {
-  outline: none;
-  border-color: rgba(255, 255, 255, 0.7);
-  background: rgba(255, 255, 255, 0.18);
-}
-
-.input:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+  justify-content: center;
+  margin-bottom: 0.25rem;
 }
 
 .button {
-  padding: 0.75rem 1.5rem;
+  padding: 0.75rem 2rem;
   font-size: 1rem;
   font-weight: 700;
   border: none;
@@ -114,46 +81,33 @@
   color: #1a2b4a;
   cursor: pointer;
   white-space: nowrap;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  transition: background 0.2s, transform 0.15s, opacity 0.2s;
-  flex-shrink: 0;
+  transition: background 0.2s, transform 0.15s;
 }
 
-.button:hover:not(:disabled) {
+.button:hover {
   background: #e0eaff;
   transform: translateY(-1px);
 }
 
-.button:disabled {
-  opacity: 0.65;
-  cursor: not-allowed;
-  transform: none;
-}
-
-/* Spinner */
-.spinner {
-  display: inline-block;
-  width: 1rem;
-  height: 1rem;
-  border: 2px solid rgba(26, 43, 74, 0.3);
-  border-top-color: #1a2b4a;
-  border-radius: 50%;
-  animation: spin 0.7s linear infinite;
-  flex-shrink: 0;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
-/* Error */
-.errorMsg {
-  color: #fca5a5;
+.buttonSecondary {
+  margin-top: 1rem;
+  padding: 0.5rem 1.25rem;
   font-size: 0.875rem;
-  margin: 0;
-  text-align: left;
+  font-weight: 600;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 0.5rem;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.8);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.buttonSecondary:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
 }
 
 /* Success state */
@@ -227,12 +181,8 @@
   border: 0;
 }
 
-/* Responsive: stack on narrow screens */
+/* Responsive: full-width button on narrow screens */
 @media (max-width: 480px) {
-  .inputRow {
-    flex-direction: column;
-  }
-
   .button {
     width: 100%;
     justify-content: center;

--- a/src/components/MailingListSignup/styles.module.css
+++ b/src/components/MailingListSignup/styles.module.css
@@ -1,11 +1,46 @@
 /* Banner wrapper */
 .banner {
-  background: linear-gradient(135deg, #1a2b4a 0%, #2563eb 60%, #1e3a5f 100%);
+  background: linear-gradient(135deg, #1a2b4a 0%, #2563eb 55%, #1e40af 100%);
   border-radius: 1rem;
   padding: 2.5rem 1.5rem;
   margin: 2rem 0;
   text-align: center;
-  box-shadow: 0 8px 32px rgba(37, 99, 235, 0.25);
+  box-shadow: 0 8px 32px rgba(37, 99, 235, 0.3);
+  position: relative;
+  overflow: hidden;
+}
+
+/* Dot-grid texture */
+.banner::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(rgba(255,255,255,0.12) 1px, transparent 1px);
+  background-size: 20px 20px;
+  pointer-events: none;
+}
+
+/* Shimmer sweep on load */
+.banner::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 60%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255,255,255,0.07) 50%,
+    transparent 100%
+  );
+  animation: bannerShimmer 3s ease-in-out 0.4s 1 both;
+  pointer-events: none;
+}
+
+@keyframes bannerShimmer {
+  from { left: -60%; }
+  to   { left: 120%; }
 }
 
 .inner {
@@ -121,18 +156,11 @@
   text-align: left;
 }
 
-/* Privacy note */
-.privacyNote {
-  color: rgba(255, 255, 255, 0.5);
-  font-size: 0.8rem;
-  margin: 0.75rem 0 0;
-}
-
 /* Success state */
 .successIcon {
   width: 3rem;
   height: 3rem;
-  background: rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.2);
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -141,6 +169,12 @@
   margin: 0 auto 1rem;
   color: #ffffff;
   line-height: 3rem;
+  animation: successPop 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+@keyframes successPop {
+  from { transform: scale(0.4); opacity: 0; }
+  to   { transform: scale(1);   opacity: 1; }
 }
 
 .successHeadline {
@@ -148,6 +182,7 @@
   font-size: 1.4rem;
   font-weight: 800;
   margin: 0 0 0.5rem;
+  animation: successFadeUp 0.35s ease-out 0.1s both;
 }
 
 .successBody {
@@ -155,6 +190,28 @@
   font-size: 1rem;
   margin: 0;
   line-height: 1.6;
+  animation: successFadeUp 0.35s ease-out 0.2s both;
+}
+
+@keyframes successFadeUp {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Privacy note */
+.privacyNote {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.8rem;
+  margin: 0.75rem 0 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+}
+
+.privacyNote::before {
+  content: '🔒';
+  font-size: 0.7rem;
 }
 
 /* Accessibility */

--- a/src/theme/CommunityWidget.jsx
+++ b/src/theme/CommunityWidget.jsx
@@ -13,9 +13,8 @@ const ACTIONS = [
   {
     id: 'newsletter',
     label: 'Subscribe to updates',
-    href: 'https://lists.cncf.io/g/cncf-cadence-community/join',
+    href: '/community/meetup#stay-updated-on-cadence',
     icon: 'mdi:email-newsletter',
-    external: true,
   },
   {
     id: 'slack',

--- a/src/theme/CommunityWidget.jsx
+++ b/src/theme/CommunityWidget.jsx
@@ -3,6 +3,8 @@ import { Icon } from '@iconify/react';
 import Link from '@docusaurus/Link';
 import styles from './CommunityWidget.module.css';
 
+const JOIN_URL = 'https://lists.cncf.io/g/cncf-cadence-community/join';
+
 const ACTIONS = [
   {
     id: 'meetup',
@@ -13,7 +15,6 @@ const ACTIONS = [
   {
     id: 'newsletter',
     label: 'Subscribe to updates',
-    href: '/community/meetup#stay-updated-on-cadence',
     icon: 'mdi:email-newsletter',
   },
   {
@@ -48,15 +49,32 @@ const ACTIONS = [
 export default function CommunityWidget() {
   const [open, setOpen] = useState(false);
   const [showTooltip, setShowTooltip] = useState(true);
+  const [emailOpen, setEmailOpen] = useState(false);
+  const [email, setEmail] = useState('');
+  const [submitted, setSubmitted] = useState(false);
   const panelRef = useRef(null);
   const fabRef = useRef(null);
   const wrapperRef = useRef(null);
+  const emailInputRef = useRef(null);
 
-  // Auto-hide tooltip after 4 s
   useEffect(() => {
     const t = setTimeout(() => setShowTooltip(false), 4000);
     return () => clearTimeout(t);
   }, []);
+
+  useEffect(() => {
+    if (emailOpen) {
+      setTimeout(() => emailInputRef.current?.focus(), 50);
+    }
+  }, [emailOpen]);
+
+  useEffect(() => {
+    if (!open) {
+      setEmailOpen(false);
+      setSubmitted(false);
+      setEmail('');
+    }
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -84,6 +102,13 @@ export default function CommunityWidget() {
     };
   }, [open]);
 
+  function handleEmailSubmit(e) {
+    e.preventDefault();
+    if (!email) return;
+    window.open(`${JOIN_URL}?email=${encodeURIComponent(email)}`, '_blank', 'noopener,noreferrer');
+    setSubmitted(true);
+  }
+
   return (
     <div className={styles.widget} aria-label="Community actions">
       {open && (
@@ -108,15 +133,58 @@ export default function CommunityWidget() {
             {ACTIONS.map((action) => {
               const isMeetup = action.id === 'meetup';
               const isNewsletter = action.id === 'newsletter';
-              const itemClass = isMeetup ? styles.actionItemMeetup : isNewsletter ? styles.actionItemNewsletter : styles.actionItem;
+
+              if (isNewsletter) {
+                return (
+                  <li key={action.id}>
+                    <button
+                      className={`${styles.actionItemNewsletter} ${styles.actionItemNewsletterBtn}`}
+                      onClick={() => { setEmailOpen((v) => !v); setSubmitted(false); }}
+                      aria-expanded={emailOpen}
+                    >
+                      <Icon icon={action.icon} className={styles.actionIcon} width={20} />
+                      <span>{action.label}</span>
+                      <span className={styles.newsletterBadge}>New</span>
+                    </button>
+                    {emailOpen && (
+                      <div className={styles.emailDrawer}>
+                        {submitted ? (
+                          <p className={styles.emailConfirm}>
+                            ✅ Tab opened — click <strong>Confirm Email Address</strong> to finish.
+                          </p>
+                        ) : (
+                          <form onSubmit={handleEmailSubmit} className={styles.emailForm}>
+                            <input
+                              ref={emailInputRef}
+                              type="email"
+                              required
+                              placeholder="you@example.com"
+                              value={email}
+                              onChange={(e) => setEmail(e.target.value)}
+                              className={styles.emailInput}
+                              aria-label="Email address"
+                            />
+                            <button
+                              type="submit"
+                              className={styles.emailSubmit}
+                              disabled={!email}
+                              aria-label="Subscribe"
+                            >
+                              <Icon icon="mdi:arrow-right" width={18} />
+                            </button>
+                          </form>
+                        )}
+                      </div>
+                    )}
+                  </li>
+                );
+              }
+
+              const itemClass = isMeetup ? styles.actionItemMeetup : styles.actionItem;
+
               return action.external ? (
                 <li key={action.id}>
-                  <a
-                    href={action.href}
-                    className={itemClass}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
+                  <a href={action.href} className={itemClass} target="_blank" rel="noopener noreferrer">
                     <Icon icon={action.icon} className={styles.actionIcon} width={20} />
                     <span>{action.label}</span>
                   </a>
@@ -127,7 +195,6 @@ export default function CommunityWidget() {
                     <Icon icon={action.icon} className={styles.actionIcon} width={20} />
                     <span>{action.label}</span>
                     {isMeetup && <span className={styles.meetupBadge}>Join</span>}
-                    {isNewsletter && <span className={styles.newsletterBadge}>New</span>}
                   </Link>
                 </li>
               );

--- a/src/theme/CommunityWidget.jsx
+++ b/src/theme/CommunityWidget.jsx
@@ -18,31 +18,28 @@ const ACTIONS = [
     icon: 'mdi:email-newsletter',
   },
   {
-    id: 'slack',
-    label: 'Join us on Slack (CNCF)',
-    href: 'https://communityinviter.com/apps/cloud-native/cncf',
-    icon: 'mdi:slack',
-    external: true,
-  },
-  {
     id: 'discord',
-    label: 'Join us on Discord',
+    label: 'Discord',
     href: 'https://discord.gg/ynvjm2Et5',
     icon: 'mdi:discord',
     external: true,
+    secondary: true,
+  },
+  {
+    id: 'slack',
+    label: 'Slack',
+    href: 'https://communityinviter.com/apps/cloud-native/cncf',
+    icon: 'mdi:slack',
+    external: true,
+    secondary: true,
   },
   {
     id: 'github',
-    label: 'Discuss on GitHub',
+    label: 'GitHub',
     href: 'https://github.com/cadence-workflow/cadence/discussions',
     icon: 'mdi:github',
     external: true,
-  },
-  {
-    id: 'contact',
-    label: 'Contact the team',
-    href: '/community/contact-us',
-    icon: 'mdi:email-outline',
+    secondary: true,
   },
 ];
 
@@ -184,8 +181,8 @@ export default function CommunityWidget() {
 
               return action.external ? (
                 <li key={action.id}>
-                  <a href={action.href} className={itemClass} target="_blank" rel="noopener noreferrer">
-                    <Icon icon={action.icon} className={styles.actionIcon} width={20} />
+                  <a href={action.href} className={`${itemClass} ${action.secondary ? styles.actionItemSecondary : ''}`} target="_blank" rel="noopener noreferrer">
+                    <Icon icon={action.icon} className={styles.actionIcon} width={action.secondary ? 18 : 20} />
                     <span>{action.label}</span>
                   </a>
                 </li>

--- a/src/theme/CommunityWidget.jsx
+++ b/src/theme/CommunityWidget.jsx
@@ -49,6 +49,7 @@ export default function CommunityWidget() {
   const [open, setOpen] = useState(false);
   const panelRef = useRef(null);
   const fabRef = useRef(null);
+  const wrapperRef = useRef(null);
 
   useEffect(() => {
     if (!open) return;
@@ -61,8 +62,8 @@ export default function CommunityWidget() {
       if (
         panelRef.current &&
         !panelRef.current.contains(e.target) &&
-        fabRef.current &&
-        !fabRef.current.contains(e.target)
+        wrapperRef.current &&
+        !wrapperRef.current.contains(e.target)
       ) {
         setOpen(false);
       }
@@ -97,12 +98,14 @@ export default function CommunityWidget() {
             </button>
           </div>
           <ul className={styles.actionList}>
-            {ACTIONS.map((action) =>
-              action.external ? (
+            {ACTIONS.map((action) => {
+              const isNewsletter = action.id === 'newsletter';
+              const itemClass = isNewsletter ? styles.actionItemNewsletter : styles.actionItem;
+              return action.external ? (
                 <li key={action.id}>
                   <a
                     href={action.href}
-                    className={styles.actionItem}
+                    className={itemClass}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
@@ -112,25 +115,28 @@ export default function CommunityWidget() {
                 </li>
               ) : (
                 <li key={action.id}>
-                  <Link to={action.href} className={styles.actionItem} onClick={() => setOpen(false)}>
+                  <Link to={action.href} className={itemClass} onClick={() => setOpen(false)}>
                     <Icon icon={action.icon} className={styles.actionIcon} width={20} />
                     <span>{action.label}</span>
+                    {isNewsletter && <span className={styles.newsletterBadge}>New</span>}
                   </Link>
                 </li>
-              )
-            )}
+              );
+            })}
           </ul>
         </div>
       )}
-      <button
-        ref={fabRef}
-        className={`${styles.fab} ${open ? styles.fabOpen : ''}`}
-        onClick={() => setOpen((v) => !v)}
-        aria-label={open ? 'Close community menu' : 'Open community actions'}
-        aria-expanded={open}
-      >
-        <Icon icon={open ? 'mdi:close' : 'mdi:account-group'} width={26} />
-      </button>
+      <div ref={wrapperRef} className={`${styles.fabWrapper} ${open ? styles.fabWrapperOpen : ''}`}>
+        <button
+          ref={fabRef}
+          className={`${styles.fab} ${open ? styles.fabOpen : ''}`}
+          onClick={() => setOpen((v) => !v)}
+          aria-label={open ? 'Close community menu' : 'Open community actions'}
+          aria-expanded={open}
+        >
+          <Icon icon={open ? 'mdi:close' : 'mdi:account-group'} width={26} />
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/theme/CommunityWidget.jsx
+++ b/src/theme/CommunityWidget.jsx
@@ -13,8 +13,9 @@ const ACTIONS = [
   {
     id: 'newsletter',
     label: 'Subscribe to updates',
-    href: '/community/meetup#stay-updated-on-cadence',
+    href: 'https://lists.cncf.io/g/cncf-cadence-community/join',
     icon: 'mdi:email-newsletter',
+    external: true,
   },
   {
     id: 'slack',

--- a/src/theme/CommunityWidget.jsx
+++ b/src/theme/CommunityWidget.jsx
@@ -5,6 +5,12 @@ import styles from './CommunityWidget.module.css';
 
 const ACTIONS = [
   {
+    id: 'newsletter',
+    label: 'Subscribe to updates',
+    href: '/community/meetup#stay-updated-on-cadence',
+    icon: 'mdi:email-newsletter',
+  },
+  {
     id: 'meetup',
     label: 'Join the community meetup',
     href: '/community/meetup',

--- a/src/theme/CommunityWidget.jsx
+++ b/src/theme/CommunityWidget.jsx
@@ -191,7 +191,7 @@ export default function CommunityWidget() {
                   <Link to={action.href} className={itemClass} onClick={() => setOpen(false)}>
                     <Icon icon={action.icon} className={styles.actionIcon} width={20} />
                     <span>{action.label}</span>
-                    {isMeetup && <span className={styles.meetupBadge}>Join</span>}
+                    {isMeetup && <span className={styles.meetupBadge}>New</span>}
                   </Link>
                 </li>
               );

--- a/src/theme/CommunityWidget.jsx
+++ b/src/theme/CommunityWidget.jsx
@@ -5,16 +5,16 @@ import styles from './CommunityWidget.module.css';
 
 const ACTIONS = [
   {
-    id: 'newsletter',
-    label: 'Subscribe to updates',
-    href: '/community/meetup#stay-updated-on-cadence',
-    icon: 'mdi:email-newsletter',
-  },
-  {
     id: 'meetup',
     label: 'Join the community meetup',
     href: '/community/meetup',
     icon: 'mdi:calendar-star',
+  },
+  {
+    id: 'newsletter',
+    label: 'Subscribe to updates',
+    href: '/community/meetup#stay-updated-on-cadence',
+    icon: 'mdi:email-newsletter',
   },
   {
     id: 'slack',
@@ -47,9 +47,16 @@ const ACTIONS = [
 
 export default function CommunityWidget() {
   const [open, setOpen] = useState(false);
+  const [showTooltip, setShowTooltip] = useState(true);
   const panelRef = useRef(null);
   const fabRef = useRef(null);
   const wrapperRef = useRef(null);
+
+  // Auto-hide tooltip after 4 s
+  useEffect(() => {
+    const t = setTimeout(() => setShowTooltip(false), 4000);
+    return () => clearTimeout(t);
+  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -99,8 +106,9 @@ export default function CommunityWidget() {
           </div>
           <ul className={styles.actionList}>
             {ACTIONS.map((action) => {
+              const isMeetup = action.id === 'meetup';
               const isNewsletter = action.id === 'newsletter';
-              const itemClass = isNewsletter ? styles.actionItemNewsletter : styles.actionItem;
+              const itemClass = isMeetup ? styles.actionItemMeetup : isNewsletter ? styles.actionItemNewsletter : styles.actionItem;
               return action.external ? (
                 <li key={action.id}>
                   <a
@@ -118,6 +126,7 @@ export default function CommunityWidget() {
                   <Link to={action.href} className={itemClass} onClick={() => setOpen(false)}>
                     <Icon icon={action.icon} className={styles.actionIcon} width={20} />
                     <span>{action.label}</span>
+                    {isMeetup && <span className={styles.meetupBadge}>Join</span>}
                     {isNewsletter && <span className={styles.newsletterBadge}>New</span>}
                   </Link>
                 </li>
@@ -127,10 +136,15 @@ export default function CommunityWidget() {
         </div>
       )}
       <div ref={wrapperRef} className={`${styles.fabWrapper} ${open ? styles.fabWrapperOpen : ''}`}>
+        {showTooltip && !open && (
+          <div className={styles.tooltip} aria-hidden="true">
+            <span>Next meetup</span>
+          </div>
+        )}
         <button
           ref={fabRef}
           className={`${styles.fab} ${open ? styles.fabOpen : ''}`}
-          onClick={() => setOpen((v) => !v)}
+          onClick={() => { setOpen((v) => !v); setShowTooltip(false); }}
           aria-label={open ? 'Close community menu' : 'Open community actions'}
           aria-expanded={open}
         >

--- a/src/theme/CommunityWidget.module.css
+++ b/src/theme/CommunityWidget.module.css
@@ -9,9 +9,47 @@
   gap: 0.75rem;
 }
 
-.fab {
+/* FAB wrapper isolates the pulse rings from the button itself */
+.fabWrapper {
+  position: relative;
   width: 3.75rem;
   height: 3.75rem;
+  flex-shrink: 0;
+}
+
+.fabWrapper::before,
+.fabWrapper::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: rgba(37, 99, 235, 0.35);
+  animation: fabPulse 2.6s ease-out infinite;
+  pointer-events: none;
+}
+
+.fabWrapper::after {
+  animation-delay: 1.3s;
+}
+
+/* Stop pulsing once the panel is open */
+.fabWrapperOpen::before,
+.fabWrapperOpen::after {
+  animation: none;
+  opacity: 0;
+}
+
+@keyframes fabPulse {
+  0%   { transform: scale(1);    opacity: 0.7; }
+  70%  { transform: scale(1.85); opacity: 0; }
+  100% { transform: scale(1.85); opacity: 0; }
+}
+
+.fab {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   border-radius: 50%;
   border: none;
   background: #2563EB;
@@ -22,7 +60,6 @@
   align-items: center;
   justify-content: center;
   transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
-  flex-shrink: 0;
 }
 
 .fab:hover {
@@ -43,6 +80,13 @@
   box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15);
   min-width: 260px;
   overflow: hidden;
+  animation: panelSlideIn 0.18s ease-out both;
+  transform-origin: bottom right;
+}
+
+@keyframes panelSlideIn {
+  from { opacity: 0; transform: scale(0.92) translateY(8px); }
+  to   { opacity: 1; transform: scale(1)    translateY(0); }
 }
 
 html[data-theme='dark'] .panel {
@@ -120,4 +164,53 @@ html[data-theme='dark'] .actionItem:hover {
 
 html[data-theme='dark'] .actionIcon {
   color: #93C5FD;
+}
+
+/* Newsletter CTA row - visually elevated as the primary action */
+.actionItemNewsletter {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  color: #1D4ED8;
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 700;
+  background: #EFF6FF;
+  border-bottom: 1px solid #DBEAFE;
+  transition: background 0.15s;
+}
+
+.actionItemNewsletter:hover {
+  background: #DBEAFE;
+  color: #1D4ED8;
+  text-decoration: none;
+}
+
+html[data-theme='dark'] .actionItemNewsletter {
+  background: rgba(37, 99, 235, 0.15);
+  border-bottom-color: rgba(37, 99, 235, 0.2);
+  color: #93C5FD;
+}
+
+html[data-theme='dark'] .actionItemNewsletter:hover {
+  background: rgba(37, 99, 235, 0.25);
+  color: #BFDBFE;
+}
+
+.newsletterBadge {
+  margin-left: auto;
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: #2563EB;
+  color: #ffffff;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+html[data-theme='dark'] .newsletterBadge {
+  background: #3B82F6;
 }

--- a/src/theme/CommunityWidget.module.css
+++ b/src/theme/CommunityWidget.module.css
@@ -268,7 +268,15 @@ html[data-theme='dark'] .meetupBadge {
   transition: background 0.15s;
 }
 
-.actionItemNewsletter:hover {
+.actionItemNewsletterBtn {
+  width: 100%;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+}
+
+.actionItemNewsletter:hover,
+.actionItemNewsletterBtn:hover {
   background: #DBEAFE;
   color: #1D4ED8;
   text-decoration: none;
@@ -280,9 +288,102 @@ html[data-theme='dark'] .actionItemNewsletter {
   color: #93C5FD;
 }
 
+html[data-theme='dark'] .actionItemNewsletterBtn:hover,
 html[data-theme='dark'] .actionItemNewsletter:hover {
   background: rgba(37, 99, 235, 0.25);
   color: #BFDBFE;
+}
+
+/* Inline email drawer */
+.emailDrawer {
+  background: #F0F7FF;
+  border-bottom: 1px solid #DBEAFE;
+  padding: 0.6rem 1rem;
+  animation: drawerSlide 0.15s ease-out both;
+}
+
+@keyframes drawerSlide {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+html[data-theme='dark'] .emailDrawer {
+  background: rgba(37, 99, 235, 0.08);
+  border-bottom-color: rgba(37, 99, 235, 0.2);
+}
+
+.emailForm {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.emailInput {
+  flex: 1;
+  padding: 0.45rem 0.65rem;
+  font-size: 0.85rem;
+  border: 1px solid #BFDBFE;
+  border-radius: 0.4rem;
+  background: #ffffff;
+  color: #1e2a3a;
+  min-width: 0;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.emailInput:focus {
+  border-color: #2563EB;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
+}
+
+.emailInput::placeholder {
+  color: #94a3b8;
+}
+
+html[data-theme='dark'] .emailInput {
+  background: #1e2a3a;
+  border-color: rgba(37, 99, 235, 0.4);
+  color: #e2e8f0;
+}
+
+html[data-theme='dark'] .emailInput::placeholder {
+  color: #64748b;
+}
+
+.emailSubmit {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 0.4rem;
+  background: #2563EB;
+  color: #ffffff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s, transform 0.1s;
+}
+
+.emailSubmit:hover:not(:disabled) {
+  background: #1D4ED8;
+  transform: scale(1.05);
+}
+
+.emailSubmit:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.emailConfirm {
+  font-size: 0.8rem;
+  color: #1D4ED8;
+  margin: 0;
+  line-height: 1.4;
+}
+
+html[data-theme='dark'] .emailConfirm {
+  color: #93C5FD;
 }
 
 .newsletterBadge {

--- a/src/theme/CommunityWidget.module.css
+++ b/src/theme/CommunityWidget.module.css
@@ -166,6 +166,93 @@ html[data-theme='dark'] .actionIcon {
   color: #93C5FD;
 }
 
+/* Floating tooltip label above the FAB */
+.tooltip {
+  position: absolute;
+  right: calc(100% + 0.75rem);
+  top: 50%;
+  transform: translateY(-50%);
+  background: #1e2a3a;
+  color: #ffffff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  padding: 0.4rem 0.75rem;
+  border-radius: 0.5rem;
+  white-space: nowrap;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.25);
+  animation: tooltipIn 0.25s ease-out both, tooltipOut 0.3s ease-in 3.7s both;
+  pointer-events: none;
+}
+
+.tooltip::after {
+  content: '';
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border: 6px solid transparent;
+  border-left-color: #1e2a3a;
+}
+
+@keyframes tooltipIn {
+  from { opacity: 0; transform: translateY(-50%) translateX(8px); }
+  to   { opacity: 1; transform: translateY(-50%) translateX(0); }
+}
+
+@keyframes tooltipOut {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+/* Meetup CTA row - top priority action */
+.actionItemMeetup {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.8rem 1rem;
+  color: #1D4ED8;
+  text-decoration: none;
+  font-size: 0.95rem;
+  font-weight: 700;
+  background: linear-gradient(90deg, #EFF6FF 0%, #DBEAFE 100%);
+  border-bottom: 2px solid #BFDBFE;
+  transition: background 0.15s;
+}
+
+.actionItemMeetup:hover {
+  background: #DBEAFE;
+  color: #1D4ED8;
+  text-decoration: none;
+}
+
+html[data-theme='dark'] .actionItemMeetup {
+  background: linear-gradient(90deg, rgba(37,99,235,0.2) 0%, rgba(37,99,235,0.12) 100%);
+  border-bottom-color: rgba(37, 99, 235, 0.3);
+  color: #93C5FD;
+}
+
+html[data-theme='dark'] .actionItemMeetup:hover {
+  background: rgba(37, 99, 235, 0.3);
+  color: #BFDBFE;
+}
+
+.meetupBadge {
+  margin-left: auto;
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: #2563EB;
+  color: #ffffff;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+html[data-theme='dark'] .meetupBadge {
+  background: #3B82F6;
+}
+
 /* Newsletter CTA row - visually elevated as the primary action */
 .actionItemNewsletter {
   display: flex;


### PR DESCRIPTION
**[What changed?]**
Added a `MailingListSignup` React component backed by Formspree for collecting visitor email addresses, embedded it on the meetup and contact-us pages, and added a site-wide shortcut in the floating community FAB.

- New `src/components/MailingListSignup/` component: email input with idle / submitting / success / error states, gradient banner design, mobile-responsive
- `community/meetup.mdx`: subscribe widget at the top, tabbed notification options (Slack / GitHub / Email), "What to expect" converted to a table
- `community/contact-us.mdx`: prose hero lead-in, widget as the first call-to-action, channel sections grouped by type (chat, GitHub, mailing list, social)
- `src/theme/CommunityWidget.jsx`: added "Subscribe to updates" as the first item in the floating FAB so the CTA is reachable from every page

**[Why?]**
The community CTA widget existed but had no working email capture. Visitors had no path to subscribe to meetup announcements or release updates. This adds that path so we can start measuring community conversion from site traffic.

**[How did you verify it?]**
`npm run build` passes with no errors or warnings beyond the pre-existing vscode-languageserver-types notice.

**[Production Preview Verification]**
- [ ] Ran `npm run preview:github-pages -- --serve` and confirmed pages load correctly
- [ ] Verified widget renders in light mode
- [ ] Verified widget renders in dark mode
- [ ] Confirmed FAB "Subscribe to updates" scrolls to the widget anchor on the meetup page
- [ ] Confirmed idle / submitting / success / error states display correctly
- [ ] Confirmed mobile layout stacks input and button correctly

**[Activation required]**
Before the form collects live submissions, replace `YOUR_FORM_ID` in `src/components/MailingListSignup/index.tsx` with the ID from a Formspree account (formspree.io → New Form → copy the ID).

**[Potential risks]**
Low. The component degrades gracefully: if the form ID is not set, the submit returns a 404 and shows the error state. No other pages or components are affected.

**[Related changes]**
None.