### PR TITLE
docs(cli): Add admonition to batch jobs docs

### DIFF
--- a/docs/06-cli/index.md
+++ b/docs/06-cli/index.md
@@ -337,6 +337,11 @@ Terminating a running :workflow_execution: will record a WorkflowExecutionTermin
 Canceling a running :workflow_execution: will record a WorkflowExecutionCancelRequested :event: in the history, and a new :decision_task: will be scheduled. The :workflow: has a chance to do some clean up work after cancellation.
 
 #### Signal, cancel, terminate workflows as a batch job
+
+:::tip New: Batch Actions UI
+You can now run and manage batch jobs directly from Cadence Web, no CLI required. See [Batch Actions UI: Manage Thousands of Workflows at Once](/blog/2026/07/07/2026-07-07-batch-actions-ui/batch-actions-ui) to learn more.
+:::
+
 Batch job is based on List Workflow Query(**--query**). It supports :signal:, cancel and terminate as batch job type.
 For terminating :workflow:workflows: as batch job, it will terminate the children recursively.
 


### PR DESCRIPTION
<!-- If you are new to contributing to Cadence-Docs or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added INFO admonition to make users aware of the new UI feature.

**Why?**
Readers landing on the CLI batch-job docs had no signal that batch actions can now be run from the UI. This adds a :::tip admonition pointing them to the new Batch Actions UI and its announcement blog post.

**How did you verify it?**
Ran the docs site locally (npm start) and confirmed the CLI page renders the banner and the blog link resolves 

**Potential risks**
Docs-only change, no runtime impact. Only risk is link rot if the blog post slug changes.

**Related changes**

Links to the existing Batch Actions UI blog post


<img width="1101" height="564" alt="image" src="https://github.com/user-attachments/assets/50925e31-d1a4-4cf0-8589-d48188c72bfb" />
