### PR TITLE
chore(config): retire 2025 OSS survey announcement bar

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -263,15 +263,6 @@ const config: Config = {
     },
   ],
   themeConfig: {
-    announcementBar: {
-      id: 'survey_2025',
-      content:
-        'We are looking to hear your feedback, please fill out the <a target="_blank" rel="noopener noreferrer" href="https://uber.surveymonkey.com/r/CY7FTZ2">Cadence 2025 OSS community survey</a>',
-      backgroundColor: '#fafbfc',
-      textColor: '#091E42',
-      isCloseable: true,
-    },
-
     // Site-wide <meta> only. Do not set description / og:title / og:description / og:url / twitter:*
     // here — they duplicate every page and often win over DocItem Layout PageMetadata in crawlers.
     // Per-page: docs/blog frontmatter `description` + `keywords`; homepage uses Layout `description` in index.tsx.


### PR DESCRIPTION
Removes the outdated 2025 survey announcement bar from the site-wide config.

**Why:** The survey has concluded and the dismissal state is persisted in localStorage keyed by the announcementBar id. Removing the component entirely prevents future visitor confusion and clears the way for new campaigns.

**Changes:**
- Deletes lines 266-273 from docusaurus.config.ts (announcementBar block in themeConfig)

**Testing:**
- Verified announcement bar no longer appears in homepage and throughout site
- Verified no console errors or visual regressions