### PR TITLE
Diana/pr2.5 faqpage schema

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -263,15 +263,6 @@ const config: Config = {
     },
   ],
   themeConfig: {
-    announcementBar: {
-      id: 'survey_2025',
-      content:
-        'We are looking to hear your feedback, please fill out the <a target="_blank" rel="noopener noreferrer" href="https://uber.surveymonkey.com/r/CY7FTZ2">Cadence 2025 OSS community survey</a>',
-      backgroundColor: '#fafbfc',
-      textColor: '#091E42',
-      isCloseable: true,
-    },
-
     // Site-wide <meta> only. Do not set description / og:title / og:description / og:url / twitter:*
     // here — they duplicate every page and often win over DocItem Layout PageMetadata in crawlers.
     // Per-page: docs/blog frontmatter `description` + `keywords`; homepage uses Layout `description` in index.tsx.

--- a/faq/cadence-faq.mdx
+++ b/faq/cadence-faq.mdx
@@ -16,6 +16,35 @@ keywords:
 permalink: /faq/cadence-faq
 ---
 
+import { FaqSchema } from '@site/src/components/FaqSchema';
+
+<FaqSchema items={[
+  {
+    question: "What is Cadence?",
+    answer: "Cadence is a durable execution engine. You write business logic as ordinary code (functions that call services, sleep for days, retry on failure), and Cadence makes that code survive process crashes, restarts, and infrastructure outages without you adding any extra state management. Think of it as a runtime that keeps your code running reliably across failures, not a framework that requires you to restructure your logic around queues, state machines, or cron jobs."
+  },
+  {
+    question: "What's the difference between a workflow and an activity?",
+    answer: "A workflow is the durable orchestration function. It defines the sequence and control flow of your business process. Workflow code must be deterministic: it cannot make network calls, read from the filesystem, or use real-world time directly, because Cadence may replay it to reconstruct state after a failure. An activity is where the actual work happens: API calls, database writes, sending emails. Activities run in your application code, are retried automatically on failure, and can be as long-running as needed. They are not subject to the determinism constraint. A simple rule of thumb: if it touches the outside world, it's an activity. If it decides what to do next, it's in the workflow."
+  },
+  {
+    question: "When should I use Cadence instead of a message queue (Kafka, SQS, RabbitMQ)?",
+    answer: "Message queues are great for point-to-point async delivery. They become painful when your process spans multiple steps with dependencies between them, needs to retry individual steps with backoff and a deadline, has to wait minutes, hours, or days between steps, must track overall progress or handle partial failures across steps, or requires exactly-once semantics across service boundaries. In those cases you end up writing a lot of glue code on top of the queue: polling tables for status, building state machines, writing retry logic. Cadence replaces that glue code with a plain function. For simple fire-and-forget fanout or high-throughput streaming, a queue is usually the right tool."
+  },
+  {
+    question: "How does Cadence handle failures?",
+    answer: "At the workflow level, Cadence automatically resumes execution from where it left off after any infrastructure failure: worker crash, server restart, network partition. Your workflow code sees none of it; execution continues as if nothing happened. At the activity level, Cadence retries failed activities according to the retry policy you configure (initial interval, backoff coefficient, max attempts, expiration). If an activity exceeds its retry budget, the error is surfaced to the workflow where your code can handle or escalate it. The only failure that actually terminates a workflow is an unhandled error thrown by your own business logic."
+  },
+  {
+    question: "Can a workflow run for a very long time?",
+    answer: "Yes. Cadence workflows can run for years. The state is persisted to the database at every step, so the workflow can be paused (e.g. waiting on a timer or a signal) without consuming any compute resources, and resume exactly where it left off. If the event history grows very large over time, use Continue-as-New to checkpoint and restart the workflow with a clean history."
+  },
+  {
+    question: "What's the difference between Cadence and Temporal?",
+    answer: "Temporal is a 2019 fork of Cadence. They share the same core execution model but have diverged since. See the Cadence vs Temporal page for a detailed comparison."
+  }
+]} />
+
 # Cadence FAQ
 
 ## What is Cadence?

--- a/src/components/FaqSchema/index.tsx
+++ b/src/components/FaqSchema/index.tsx
@@ -25,9 +25,12 @@ export function FaqSchema({ items }: FaqSchemaProps): JSX.Element {
 
   return (
     <Head>
-      <script type="application/ld+json">
-        {JSON.stringify(schema)}
-      </script>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(schema).replace(/</g, '\u003c'),
+        }}
+      />
     </Head>
   );
 }

--- a/src/components/FaqSchema/index.tsx
+++ b/src/components/FaqSchema/index.tsx
@@ -1,0 +1,33 @@
+import Head from '@docusaurus/Head';
+
+interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+interface FaqSchemaProps {
+  items: FaqItem[];
+}
+
+export function FaqSchema({ items }: FaqSchemaProps): JSX.Element {
+  const schema = {
+    '@context': 'https://schema.org/',
+    '@type': 'FAQPage',
+    mainEntity: items.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer,
+      },
+    })),
+  };
+
+  return (
+    <Head>
+      <script type="application/ld+json">
+        {JSON.stringify(schema)}
+      </script>
+    </Head>
+  );
+}


### PR DESCRIPTION
**What changed**
Added a reusable FaqSchema component that emits FAQPage structured data as JSON-LD. Applied it to cadence-faq.mdx with all 6 FAQ questions and answers extracted from the visible on-page content.

New file: src/components/FaqSchema/index.tsx
Updated: faq/cadence-faq.mdx (import + component call with 6 Q&A pairs)

**Why**
Google Search can now parse and understand the FAQ structure. This enables rich snippet display in search results, which improves click-through rates from Google Search Console. The FAQPage schema is a best practice for content that already uses visible Q&A formatting.

**How did you verify it**
Built the site and confirmed the FAQPage JSON-LD schema is present in /faq/cadence-faq.html
Verified all 6 question/answer pairs are valid JSON-LD format
Confirmed schema answers match visible on-page FAQ sections exactly (Google requirement: schema text must correspond to content users actually see)
Tested page rendering at 390px width and in dark mode; no visual changes

**Potential risks**
If schema question/answer text diverges from visible content, Google can ignore the markup or flag it as misleading. Mitigation: answers are extracted directly from the visible FAQ body, not written separately. Any future FAQ updates must keep schema and visible text in sync.

**Related changes**
Independent. PR 1 handles survey bar retirement.