### PR TITLE
feat(homepage): rebuild hero around a code preview and social proof

### DIFF
--- a/src/components/FeaturedCarousel/index.tsx
+++ b/src/components/FeaturedCarousel/index.tsx
@@ -198,7 +198,7 @@ export default function FeaturedCarousel(): JSX.Element {
       <div className="container">
         <div className={styles.header}>
           <Heading as="h2" className={styles.title}>
-            Featured reading
+            What's new?
           </Heading>
           <div className={styles.controls}>
             <button

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -26,13 +26,66 @@
   margin-bottom: 0.6rem;
 }
 
-/* ~2x button--sm's font-size, with a tight line-height and only a slight
-   padding bump so the CTA doesn't grow much taller than button--sm despite
-   the much bigger text. */
-.heroCompactCta {
+/* CTA row: a primary action, a comparison secondary, and a tertiary text link.
+   Left-aligned so the buttons sit over the blue side of the hero gradient,
+   where white type/borders stay high-contrast. */
+.heroCtas {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.15rem;
+}
+
+/* Shared CTA sizing — ~2x button--sm text with a tight line-height so the
+   buttons don't grow much taller than button--sm despite the bigger label. */
+.heroCtaPrimary,
+.heroCtaSecondary {
   font-size: 1.1rem;
   line-height: 1;
-  padding: 0.50rem 1.0rem;
+  padding: 0.6rem 1.15rem;
+  font-weight: 600;
+  border: 2px solid transparent;
+}
+
+/* Primary: solid black reads as the single most important action and stands
+   apart from the white hero type around it. */
+.heroCtaPrimary {
+  background-color: #000;
+  border-color: #000;
+  color: #fff;
+}
+.heroCtaPrimary:hover {
+  background-color: #1a1a1a;
+  color: #fff;
+  text-decoration: none;
+}
+
+/* Secondary: white outline for the comparison shoppers, quieter than primary
+   but still a clear button on the blue gradient. */
+.heroCtaSecondary {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+.heroCtaSecondary:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  text-decoration: none;
+}
+
+/* Tertiary: the old "What is Cadence?" definition link, demoted to a text
+   link so it no longer competes with the actions that move people forward. */
+.heroCtaTertiary {
+  font-size: 1rem;
+  font-weight: 500;
+  color: #fff;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  margin-left: 0.25rem;
+}
+.heroCtaTertiary:hover {
+  color: #f0f0f0;
 }
 
 @media screen and (max-width: 996px) {

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -39,7 +39,7 @@
 .heroCompactSubtitle {
   font-size: 1.1rem;
   line-height: 1.4;
-  max-width: 44ch;
+  max-width: 62ch;
   margin-bottom: 1.1rem;
   opacity: 0.95;
 }
@@ -115,7 +115,9 @@
   color: #fff;
   text-decoration: underline;
   text-underline-offset: 3px;
-  margin-left: 0.25rem;
+  /* Extra separation so this quiet link reads as its own thing, set apart
+     from the two primary/secondary buttons rather than crowding them. */
+  margin-left: 1.25rem;
 }
 .heroCtaTertiary:hover {
   color: #f0f0f0;

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -6,6 +6,9 @@
 .heroBanner {
   /* Uber Safety Blue to Cosmic Latte */
   background: linear-gradient(90deg, #276ef1 05%, #FFF8E7 100%);
+  /* positioning context for the gear watermark; clip it to the banner */
+  position: relative;
+  overflow: hidden;
 }
 
 .hero.heroBanner .button--secondary.button--sm {
@@ -13,17 +16,47 @@
 }
 
 .heroCompact {
-  padding: 1.25rem 1rem;
+  padding: 2.25rem 1rem 2.5rem;
+}
+
+/* Keep hero content above the watermark and hold the copy to a readable
+   measure so the headline and subtitle wrap on the blue side of the gradient. */
+.heroInner {
+  position: relative;
+  z-index: 1;
 }
 
 .heroCompactTitle {
-  font-size: 1.75rem;
-  margin-bottom: 0.35rem;
+  font-size: 2.75rem;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  font-weight: 800;
+  margin-bottom: 0.5rem;
+  max-width: 15ch;
+  text-wrap: balance;
 }
 
 .heroCompactSubtitle {
-  font-size: 0.95rem;
-  margin-bottom: 0.6rem;
+  font-size: 1.1rem;
+  line-height: 1.4;
+  max-width: 44ch;
+  margin-bottom: 1.1rem;
+  opacity: 0.95;
+}
+
+/* Faint brand gear filling the otherwise-empty cream side of the gradient.
+   Decorative only (empty alt + aria-hidden); hidden on narrow screens where
+   the hero copy needs the full width. */
+.heroMark {
+  position: absolute;
+  top: 50%;
+  right: -1.5rem;
+  transform: translateY(-50%);
+  width: 320px;
+  height: auto;
+  opacity: 0.12;
+  pointer-events: none;
+  user-select: none;
 }
 
 /* CTA row: a primary action, a comparison secondary, and a tertiary text link.
@@ -37,7 +70,7 @@
   margin-top: 0.15rem;
 }
 
-/* Shared CTA sizing — ~2x button--sm text with a tight line-height so the
+/* Shared CTA sizing: ~2x button--sm text with a tight line-height so the
    buttons don't grow much taller than button--sm despite the bigger label. */
 .heroCtaPrimary,
 .heroCtaSecondary {
@@ -90,10 +123,20 @@
 
 @media screen and (max-width: 996px) {
   .heroCompact {
-    padding: 1rem;
+    padding: 1.75rem 1rem 2rem;
   }
 
   .heroCompactTitle {
-    font-size: 1.5rem;
+    font-size: 2.1rem;
+    max-width: 100%;
+  }
+
+  .heroCompactSubtitle {
+    font-size: 1rem;
+  }
+
+  /* Reclaim full width for the copy on phones/tablets. */
+  .heroMark {
+    display: none;
   }
 }

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -6,24 +6,37 @@
 .heroBanner {
   /* Uber Safety Blue to Cosmic Latte */
   background: linear-gradient(90deg, #276ef1 05%, #FFF8E7 100%);
-  /* positioning context for the gear watermark; clip it to the banner */
+  /* positioning context for .heroInner; clip any code panel overflow */
   position: relative;
   overflow: hidden;
-}
-
-.hero.heroBanner .button--secondary.button--sm {
-  background-color: black;
 }
 
 .heroCompact {
   padding: 2.25rem 1rem 2.5rem;
 }
 
-/* Keep hero content above the watermark and hold the copy to a readable
-   measure so the headline and subtitle wrap on the blue side of the gradient. */
+/* Two columns on desktop: copy over the blue end of the gradient where white
+   type stays high-contrast, code panel over the cream end. min-width: 0 lets
+   the panel scroll internally instead of stretching the row. */
 .heroInner {
   position: relative;
   z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 2.5rem;
+}
+
+.heroCopy,
+.heroCode {
+  flex: 1 1 50%;
+  min-width: 0;
+}
+
+/* The gradient is hardcoded identically in both color modes, so pin the copy to
+   white. Inheriting Infima's --ifm-hero-text-color would turn it black in dark
+   mode, leaving the title and subtitle dark on the blue end of the gradient. */
+.heroCopy {
+  color: #fff;
 }
 
 .heroCompactTitle {
@@ -36,6 +49,8 @@
   text-wrap: balance;
 }
 
+/* The 62ch cap only binds once the layout stacks; on desktop the column itself
+   is the narrower constraint. */
 .heroCompactSubtitle {
   font-size: 1.1rem;
   line-height: 1.4;
@@ -44,22 +59,80 @@
   opacity: 0.95;
 }
 
-/* Faint brand gear filling the otherwise-empty cream side of the gradient.
-   Decorative only (empty alt + aria-hidden); hidden on narrow screens where
-   the hero copy needs the full width. */
-.heroMark {
-  position: absolute;
-  top: 50%;
-  right: -1.5rem;
-  transform: translateY(-50%);
-  width: 320px;
-  height: auto;
-  opacity: 0.12;
-  pointer-events: none;
-  user-select: none;
+/* Social proof eyebrow above the headline, shaped like the FeaturedCarousel
+   .tag so it reads as native UI. Translucent fill keeps it quieter than the
+   CTAs below it. */
+.heroEyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-bottom: 0.85rem;
+  padding: 0.3rem 0.7rem;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  background-color: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 600;
 }
 
-/* CTA row: a primary action, a comparison secondary, and a tertiary text link.
+/* Smaller than .heroCtaIcon to match the pill's smaller type. */
+.heroEyebrowIcon {
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
+}
+
+.heroEyebrowSep {
+  margin: 0 0.15rem;
+  opacity: 0.55;
+}
+
+/* Only this segment is interactive: the star count next to it is static text,
+   so the link affordance sits on the words rather than on the whole pill. */
+.heroEyebrowLink {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: rgba(255, 255, 255, 0.5);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
+}
+.heroEyebrowLink:hover {
+  color: inherit;
+  text-decoration-color: currentColor;
+}
+.heroEyebrowLink:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Dark panel for the workflow snippet. The shadow separates it from the cream
+   end of the gradient; the hairline border reads as an inner highlight. */
+.heroCode {
+  padding: 1rem 1.15rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  background-color: #0B0F19;
+  box-shadow: 0 12px 30px rgba(11, 15, 25, 0.28);
+  overflow: auto;
+}
+
+.heroCodePre {
+  margin: 0;
+  padding: 0;
+  font-size: 0.8rem;
+  line-height: 1.55;
+  text-align: left;
+  /* The snippet is tab-indented Go; the 8-column default would eat the column. */
+  tab-size: 2;
+}
+
+.heroCodeLine {
+  display: block;
+}
+
+/* CTA row: one primary action and one outlined GitHub action.
    Left-aligned so the buttons sit over the blue side of the hero gradient,
    where white type/borders stay high-contrast. */
 .heroCtas {
@@ -71,9 +144,13 @@
 }
 
 /* Shared CTA sizing: ~2x button--sm text with a tight line-height so the
-   buttons don't grow much taller than button--sm despite the bigger label. */
+   buttons don't grow much taller than button--sm despite the bigger label.
+   inline-flex centers the GitHub glyph against its label. */
 .heroCtaPrimary,
 .heroCtaSecondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
   font-size: 1.1rem;
   line-height: 1;
   padding: 0.6rem 1.15rem;
@@ -81,20 +158,28 @@
   border: 2px solid transparent;
 }
 
-/* Primary: solid black reads as the single most important action and stands
-   apart from the white hero type around it. */
+.heroCtaIcon {
+  width: 1.15em;
+  height: 1.15em;
+  flex-shrink: 0;
+}
+
+/* Primary: the same dark slate as the code panel, which ties the two hero
+   columns together and reads softer than plain black while holding more
+   contrast against the blue gradient than a white fill would. */
 .heroCtaPrimary {
-  background-color: #000;
-  border-color: #000;
+  background-color: #0B0F19;
+  border-color: #0B0F19;
   color: #fff;
 }
 .heroCtaPrimary:hover {
-  background-color: #1a1a1a;
+  background-color: #1b2437;
+  border-color: #1b2437;
   color: #fff;
   text-decoration: none;
 }
 
-/* Secondary: white outline for the comparison shoppers, quieter than primary
+/* Secondary: white outline for the GitHub action, quieter than primary
    but still a clear button on the blue gradient. */
 .heroCtaSecondary {
   background-color: transparent;
@@ -107,25 +192,28 @@
   text-decoration: none;
 }
 
-/* Tertiary: the old "What is Cadence?" definition link, demoted to a text
-   link so it no longer competes with the actions that move people forward. */
-.heroCtaTertiary {
-  font-size: 1rem;
-  font-weight: 500;
-  color: #fff;
-  text-decoration: underline;
-  text-underline-offset: 3px;
-  /* Extra separation so this quiet link reads as its own thing, set apart
-     from the two primary/secondary buttons rather than crowding them. */
-  margin-left: 1.25rem;
-}
-.heroCtaTertiary:hover {
-  color: #f0f0f0;
+.heroCtaPrimary:focus-visible,
+.heroCtaSecondary:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
 }
 
 @media screen and (max-width: 996px) {
   .heroCompact {
     padding: 1.75rem 1rem 2rem;
+  }
+
+  /* Stack the code panel under the copy. flex-basis has to drop to auto here:
+     a 50% basis would resolve against the column's height. */
+  .heroInner {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.5rem;
+  }
+
+  .heroCopy,
+  .heroCode {
+    flex: 0 0 auto;
   }
 
   .heroCompactTitle {
@@ -137,8 +225,19 @@
     font-size: 1rem;
   }
 
-  /* Reclaim full width for the copy on phones/tablets. */
-  .heroMark {
-    display: none;
+  .heroCodePre {
+    font-size: 0.75rem;
+  }
+
+  /* Stack the CTAs full width so each is an easy tap target. */
+  .heroCtas {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .heroCtaPrimary,
+  .heroCtaSecondary {
+    width: 100%;
+    justify-content: center;
   }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,7 +23,8 @@ function HomepageHeader() {
           Orchestrate with Confidence
         </Heading>
         <p className={clsx('hero__subtitle', styles.heroCompactSubtitle)}>
-          The open-source workflow engine for durable, reliable applications. Built for tomorrow.
+          The open-source workflow engine for durable,<br />
+          reliable, and massively scalable applications built for tomorrow.
         </p>
         <div className={styles.heroCtas}>
           <Link href="/docs/get-started" className={clsx('button button--sm', styles.heroCtaPrimary)}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import Layout from '@theme/Layout';
 import FeaturedCarousel from '@site/src/components/FeaturedCarousel';
 import Heading from '@theme/Heading';
@@ -8,15 +9,22 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 function HomepageHeader() {
-  const { siteConfig } = useDocusaurusContext();
+  // Brand gear used as a faint watermark on the cream side of the gradient.
+  // useBaseUrl keeps the path correct under a project baseUrl (e.g. /Cadence-Docs/).
+  const gearMark = useBaseUrl('/img/logo/icon/color/cadence-icon-color.svg');
 
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner, styles.heroCompact)}>
-      <div className="container">
+      <img src={gearMark} alt="" aria-hidden="true" className={styles.heroMark} />
+      <div className={clsx('container', styles.heroInner)}>
+        {/* The navbar already carries the Cadence wordmark, so the hero leads
+            with the value proposition instead of repeating the brand name. */}
         <Heading as="h1" className={clsx('hero__title', styles.heroCompactTitle)}>
-          {siteConfig.title}
+          Orchestrate with Confidence
         </Heading>
-        <p className={clsx('hero__subtitle', styles.heroCompactSubtitle)}>{siteConfig.tagline}</p>
+        <p className={clsx('hero__subtitle', styles.heroCompactSubtitle)}>
+          The open-source workflow engine for durable, reliable applications. Built for tomorrow.
+        </p>
         <div className={styles.heroCtas}>
           <Link href="/docs/get-started" className={clsx('button button--sm', styles.heroCtaPrimary)}>
             Get started in 5 min

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,42 +1,116 @@
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import useBaseUrl from '@docusaurus/useBaseUrl';
 import Layout from '@theme/Layout';
 import FeaturedCarousel from '@site/src/components/FeaturedCarousel';
 import Heading from '@theme/Heading';
+import { Highlight, themes } from 'prism-react-renderer';
 
 import styles from './index.module.css';
 
-function HomepageHeader() {
-  // Brand gear used as a faint watermark on the cream side of the gradient.
-  // useBaseUrl keeps the path correct under a project baseUrl (e.g. /Cadence-Docs/).
-  const gearMark = useBaseUrl('/img/logo/icon/color/cadence-icon-color.svg');
+const GITHUB_REPO_URL = 'https://github.com/cadence-workflow/cadence';
+const ADOPTERS_URL = `${GITHUB_REPO_URL}/blob/master/ADOPTERS.md`;
 
+// Condensed from the SubscriptionWorkflow in docs/03-concepts/12-workflow-engine.md.
+// Lines are held under ~64 columns so the snippet fits the hero's half-width
+// column without horizontal scrolling on desktop.
+const HERO_SNIPPET = `func SubscriptionWorkflow(ctx workflow.Context, id string) error {
+	ctx = workflow.WithActivityOptions(ctx, opts)
+
+	// Cadence retries this activity for you.
+	err := workflow.ExecuteActivity(ctx, Charge, id).Get(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	// Durable sleep: survives worker restarts.
+	workflow.Sleep(ctx, 30*24*time.Hour)
+	return workflow.ExecuteActivity(ctx, Renew, id).Get(ctx, nil)
+}`;
+
+// Inlined rather than pulled from @iconify/react: that library fetches icon
+// data at runtime, which leaves an empty placeholder in the SSR'd hero.
+function GitHubMark({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" className={className}>
+      <path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.09 1.84 1.24 1.84 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.34-5.47-5.96 0-1.32.47-2.39 1.24-3.23-.13-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.66.25 2.88.12 3.18.77.84 1.24 1.91 1.24 3.23 0 4.63-2.81 5.65-5.49 5.95.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58C20.57 22.29 24 17.8 24 12.5 24 5.87 18.63.5 12 .5z" />
+    </svg>
+  );
+}
+
+// prism-react-renderer instead of @theme/CodeBlock: CodeBlock picks its token
+// colors from the site color mode, which would render light tokens inside this
+// permanently dark panel. Pinning a dark theme keeps the panel identical in
+// both color modes.
+function HeroCodePreview() {
+  return (
+    <div className={styles.heroCode}>
+      <Highlight theme={themes.nightOwl} code={HERO_SNIPPET} language="go">
+        {({ className, style, tokens, getLineProps, getTokenProps }) => (
+          <pre
+            className={clsx(className, styles.heroCodePre)}
+            style={{ ...style, background: 'transparent' }}>
+            <code>
+              {tokens.map((line, lineIndex) => (
+                <span
+                  key={lineIndex}
+                  {...getLineProps({ line, className: styles.heroCodeLine })}>
+                  {line.map((token, tokenIndex) => (
+                    <span key={tokenIndex} {...getTokenProps({ token })} />
+                  ))}
+                </span>
+              ))}
+            </code>
+          </pre>
+        )}
+      </Highlight>
+    </div>
+  );
+}
+
+function HomepageHeader() {
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner, styles.heroCompact)}>
-      <img src={gearMark} alt="" aria-hidden="true" className={styles.heroMark} />
       <div className={clsx('container', styles.heroInner)}>
-        {/* The navbar already carries the Cadence wordmark, so the hero leads
-            with the value proposition instead of repeating the brand name. */}
-        <Heading as="h1" className={clsx('hero__title', styles.heroCompactTitle)}>
-          Orchestrate with Confidence
-        </Heading>
-        <p className={clsx('hero__subtitle', styles.heroCompactSubtitle)}>
-          The open-source workflow engine for durable,<br />
-          reliable, and massively scalable applications built for tomorrow.
-        </p>
-        <div className={styles.heroCtas}>
-          <Link href="/docs/get-started" className={clsx('button button--sm', styles.heroCtaPrimary)}>
-            Get started in 5 min
-          </Link>
-          <Link href="/faq/cadence-vs-temporal" className={clsx('button button--sm', styles.heroCtaSecondary)}>
-            Cadence vs Temporal
-          </Link>
-          <Link href="/faq/cadence-faq" className={styles.heroCtaTertiary}>
-            What is Cadence? →
-          </Link>
+        <div className={styles.heroCopy}>
+          <span className={styles.heroEyebrow}>
+            <GitHubMark className={styles.heroEyebrowIcon} />
+            9k+ Stars on GitHub
+            <span aria-hidden="true" className={styles.heroEyebrowSep}>
+              •
+            </span>
+            <Link
+              href={ADOPTERS_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.heroEyebrowLink}>
+              See Adopters
+            </Link>
+          </span>
+          {/* The navbar already carries the Cadence wordmark, so the hero leads
+              with the value proposition instead of repeating the brand name. */}
+          <Heading as="h1" className={clsx('hero__title', styles.heroCompactTitle)}>
+            Orchestrate with Confidence
+          </Heading>
+          <p className={clsx('hero__subtitle', styles.heroCompactSubtitle)}>
+            Write fault-tolerant, stateful background workflows as code in Go, Java and Python
+            without worrying about retries, queues, or state persistence.
+          </p>
+          <div className={styles.heroCtas}>
+            <Link to="/docs/get-started" className={clsx('button button--sm', styles.heroCtaPrimary)}>
+              Get Started in 5 min
+            </Link>
+            <Link
+              href={GITHUB_REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={clsx('button button--sm', styles.heroCtaSecondary)}>
+              <GitHubMark className={styles.heroCtaIcon} />
+              View on GitHub
+            </Link>
+          </div>
         </div>
+        <HeroCodePreview />
       </div>
     </header>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,9 +17,17 @@ function HomepageHeader() {
           {siteConfig.title}
         </Heading>
         <p className={clsx('hero__subtitle', styles.heroCompactSubtitle)}>{siteConfig.tagline}</p>
-        <Link href="/faq/cadence-faq" className={clsx('button button--secondary button--sm', styles.heroCompactCta)}>
-         🔬 What is Cadence?
-        </Link>
+        <div className={styles.heroCtas}>
+          <Link href="/docs/get-started" className={clsx('button button--sm', styles.heroCtaPrimary)}>
+            Get started in 5 min
+          </Link>
+          <Link href="/faq/cadence-vs-temporal" className={clsx('button button--sm', styles.heroCtaSecondary)}>
+            Cadence vs Temporal
+          </Link>
+          <Link href="/faq/cadence-faq" className={styles.heroCtaTertiary}>
+            What is Cadence? →
+          </Link>
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
**What changed?**

- Rebuilt the homepage hero (`src/pages/index.tsx`, `src/pages/index.module.css`) into a two-column layout where the right column is a syntax-highlighted Go workflow snippet,
- Renamed the homepage carousel heading in `src/components/FeaturedCarousel/index.tsx` from "Featured reading" to "What's new?".

**Why?**

The hero is where new visitors decide whether to click through, and it was working against us: half of it was a decorative gear watermark, and the only credibility signal sat *below* the buttons, where it arrives after the ask instead of before it.


**How did you verify it?**

- [x]  Checked at 1440px and 390px. The columns stack below 996px, the code panel scrolls horizontally inside its own `pre` on mobile rather than clipping, and the CTAs go full width.
- [x]  Checked CTA hover and keyboard focus states.


- [x] Ran production preview (`npm run preview:github-pages -- --serve`)
- [x] Checked dark mode and light mode on affected pages

**Potential risks**

- The star count is the hardcoded string "9k+" and will drift as the repo grows; it is not fetched from the API.
- The GitHub mark now appears twice in the hero, in the eyebrow and in the secondary CTA. Intentional, but worth a second opinion.


**Related changes**

This branch builds on three unmerged commits by @zawadzkidiana (`ab790306`, `a61129bd`, `7b1d7ad2`) that add the original hero CTAs. They were not on upstream, so they appear in this diff and are included here rather than reviewed separately. 

Screen Shot:
<img width="3000" height="746" alt="image" src="https://github.com/user-attachments/assets/dc1a7937-c4f8-410c-81b1-97dde8916196" />
