### PR TITLE
docs(seo): add tutorial keywords to pages with samples tables

### DIFF
--- a/docs/02-use-cases/01-periodic-execution.md
+++ b/docs/02-use-cases/01-periodic-execution.md
@@ -9,6 +9,7 @@ keywords:
   - cadence scheduled workflow
   - cadence recurring workflow
   - cadence cron use case
+  - cadence periodic execution tutorial
 permalink: /docs/use-cases/periodic-execution
 ---
 

--- a/docs/02-use-cases/02-orchestration.md
+++ b/docs/02-use-cases/02-orchestration.md
@@ -10,6 +10,7 @@ keywords:
   - cadence workflow compensation
   - cadence retry
   - cadence use case
+  - cadence orchestration tutorial
 permalink: /docs/use-cases/orchestration
 ---
 

--- a/docs/02-use-cases/03-polling.md
+++ b/docs/02-use-cases/03-polling.md
@@ -9,6 +9,7 @@ keywords:
   - cadence S3 polling
   - cadence monitoring use case
   - cadence heartbeat
+  - cadence polling tutorial
 permalink: /docs/use-cases/polling
 ---
 

--- a/docs/02-use-cases/04-event-driven.md
+++ b/docs/02-use-cases/04-event-driven.md
@@ -10,6 +10,7 @@ keywords:
   - cadence loyalty program
   - cadence fraud detection
   - cadence use case
+  - cadence event driven application tutorial
 permalink: /docs/use-cases/event-driven
 ---
 

--- a/docs/02-use-cases/05-partitioned-scan.md
+++ b/docs/02-use-cases/05-partitioned-scan.md
@@ -10,6 +10,7 @@ keywords:
   - cadence heartbeat progress
   - cadence activity scan
   - cadence use case
+  - cadence storage scan tutorial
 permalink: /docs/use-cases/partitioned-scan
 ---
 

--- a/docs/02-use-cases/06-batch-job.md
+++ b/docs/02-use-cases/06-batch-job.md
@@ -10,6 +10,7 @@ keywords:
   - cadence durability
   - cadence high throughput
   - cadence use case
+  - cadence batch job tutorial
 permalink: /docs/use-cases/batch-job
 ---
 

--- a/docs/02-use-cases/07-provisioning.md
+++ b/docs/02-use-cases/07-provisioning.md
@@ -10,6 +10,7 @@ keywords:
   - cadence locking
   - cadence fault tolerant provisioning
   - cadence use case
+  - cadence infrastructure provisioning tutorial
 permalink: /docs/use-cases/provisioning
 ---
 

--- a/docs/02-use-cases/10-interactive.md
+++ b/docs/02-use-cases/10-interactive.md
@@ -9,6 +9,7 @@ keywords:
   - interactive workflow
   - cadence background task
   - cadence session state
+  - cadence interactive application tutorial
 permalink: /docs/use-cases/interactive
 ---
 

--- a/docs/02-use-cases/11-dsl.md
+++ b/docs/02-use-cases/11-dsl.md
@@ -11,6 +11,7 @@ keywords:
   - dsl workflow engine
   - cadence bpmn
   - cadence iwf
+  - cadence dsl workflows tutorial
 permalink: /docs/use-cases/dsl
 ---
 

--- a/docs/02-use-cases/12-big-ml.md
+++ b/docs/02-use-cases/12-big-ml.md
@@ -10,6 +10,7 @@ keywords:
   - cadence use case
   - cadence ml pipeline
   - cadence task routing
+  - cadence big data ml tutorial
 permalink: /docs/use-cases/big-ml
 ---
 

--- a/docs/03-concepts/01-workflows.md
+++ b/docs/03-concepts/01-workflows.md
@@ -13,6 +13,7 @@ keywords:
   - cadence workflow definition
   - cadence workflow example
   - durable workflow
+  - cadence workflows tutorial
 permalink: /docs/concepts/workflows
 ---
 

--- a/docs/03-concepts/02-activities.md
+++ b/docs/03-concepts/02-activities.md
@@ -10,6 +10,7 @@ keywords:
   - cadence heartbeat
   - long running activity
   - cadence activity worker
+  - cadence activities tutorial
 permalink: /docs/concepts/activities
 ---
 

--- a/docs/03-concepts/03-events.md
+++ b/docs/03-concepts/03-events.md
@@ -11,6 +11,7 @@ keywords:
   - cadence human task
   - cadence synchronization
   - cadence signalWorkflowExecution
+  - cadence event handling tutorial
 permalink: /docs/concepts/events
 ---
 

--- a/docs/03-concepts/04-queries.md
+++ b/docs/03-concepts/04-queries.md
@@ -10,6 +10,7 @@ keywords:
   - cadence query workflow
   - cadence concepts
   - read workflow state
+  - cadence synchronous query tutorial
 permalink: /docs/concepts/queries
 ---
 

--- a/docs/03-concepts/06-task-lists.md
+++ b/docs/03-concepts/06-task-lists.md
@@ -10,6 +10,7 @@ keywords:
   - cadence worker routing
   - cadence concepts
   - cadence task dispatch
+  - cadence task lists tutorial
 permalink: /docs/concepts/task-lists
 ---
 

--- a/docs/03-concepts/09-search-workflows.md
+++ b/docs/03-concepts/09-search-workflows.md
@@ -11,6 +11,7 @@ keywords:
   - cadence workflow query
   - cadence concepts
   - cadence memo
+  - cadence search workflows tutorial
 permalink: /docs/concepts/search-workflows
 ---
 

--- a/docs/03-concepts/11-data-converter.md
+++ b/docs/03-concepts/11-data-converter.md
@@ -10,6 +10,7 @@ keywords:
   - workflow serialization
   - custom data converter
   - history payload size
+  - cadence data converter tutorial
 permalink: /docs/concepts/data-converter
 ---
 

--- a/docs/03-concepts/13-workflow-queries-formatted-data.md
+++ b/docs/03-concepts/13-workflow-queries-formatted-data.md
@@ -10,6 +10,7 @@ keywords:
   - cadence query formatted output
   - cadence web custom controls
   - workflow internal state
+  - cadence custom workflow controls tutorial
 permalink: /docs/concepts/workflow-queries-formatted-data
 ---
 

--- a/docs/03-concepts/14-mutual-tls.md
+++ b/docs/03-concepts/14-mutual-tls.md
@@ -10,6 +10,7 @@ keywords:
   - cadence certificate auth
   - cadence client server tls
   - cadence encryption in transit
+  - cadence mutual tls tutorial
 permalink: /docs/concepts/mutual-tls
 ---
 

--- a/docs/03-concepts/16-schedules.md
+++ b/docs/03-concepts/16-schedules.md
@@ -13,6 +13,7 @@ keywords:
   - cadence schedule catch-up
   - cadence scheduler
   - workflow scheduling
+  - cadence schedules tutorial
 permalink: /docs/concepts/schedules
 ---
 

--- a/docs/03-concepts/17-timers.md
+++ b/docs/03-concepts/17-timers.md
@@ -7,6 +7,7 @@ keywords:
   - cadence timer tasks
   - cadence workflow sleep
   - cadence global domain timers
+  - cadence timers tutorial
 permalink: /docs/concepts/timers
 ---
 

--- a/docs/04-java-client/02-workflow-interface.md
+++ b/docs/04-java-client/02-workflow-interface.md
@@ -10,6 +10,7 @@ keywords:
   - cadence java workflow definition
   - java workflow annotations
   - cadence workflow interface java
+  - cadence java workflow interface tutorial
 permalink: /docs/java-client/workflow-interface
 ---
 

--- a/docs/04-java-client/03-implementing-workflows.md
+++ b/docs/04-java-client/03-implementing-workflows.md
@@ -10,6 +10,7 @@ keywords:
   - cadence workflow code java
   - newActivityStub java
   - cadence java workflow example
+  - cadence java implementing workflows tutorial
 permalink: /docs/java-client/implementing-workflows
 ---
 

--- a/docs/04-java-client/04-starting-workflow-executions.md
+++ b/docs/04-java-client/04-starting-workflow-executions.md
@@ -10,6 +10,7 @@ keywords:
   - cadence grpc java
   - cadence tchannel java
   - cadence java client setup
+  - cadence java start workflow tutorial
 permalink: /docs/java-client/starting-workflow-executions
 ---
 

--- a/docs/04-java-client/05-activity-interface.md
+++ b/docs/04-java-client/05-activity-interface.md
@@ -10,6 +10,7 @@ keywords:
   - cadence activity java
   - activity interface java
   - cadence java activity example
+  - cadence java activity interface tutorial
 permalink: /docs/java-client/activity-interface
 ---
 

--- a/docs/04-java-client/06-implementing-activities.md
+++ b/docs/04-java-client/06-implementing-activities.md
@@ -10,6 +10,7 @@ keywords:
   - java activity execution history
   - cadence activity best practices
   - cadence java activity example
+  - cadence java implementing activities tutorial
 permalink: /docs/java-client/implementing-activities
 ---
 

--- a/docs/04-java-client/08-distributed-cron.md
+++ b/docs/04-java-client/08-distributed-cron.md
@@ -10,6 +10,7 @@ keywords:
   - cadence recurring workflow
   - cadence cron schedule
   - cadence java cron example
+  - cadence java distributed cron tutorial
 permalink: /docs/java-client/distributed-cron
 ---
 

--- a/docs/04-java-client/09-workers.md
+++ b/docs/04-java-client/09-workers.md
@@ -10,6 +10,7 @@ keywords:
   - register workflow java
   - cadence task list java
   - cadence worker configuration
+  - cadence java worker tutorial
 permalink: /docs/java-client/workers
 ---
 

--- a/docs/04-java-client/10-signals.md
+++ b/docs/04-java-client/10-signals.md
@@ -10,6 +10,7 @@ keywords:
   - cadence async signal
   - cadence signal channel
   - cadence java signal example
+  - cadence java signals tutorial
 permalink: /docs/java-client/signals
 ---
 

--- a/docs/04-java-client/11-queries.md
+++ b/docs/04-java-client/11-queries.md
@@ -10,6 +10,7 @@ keywords:
   - cadence stack trace query
   - cadence java query example
   - cadence read workflow state
+  - cadence java queries tutorial
 permalink: /docs/java-client/queries
 ---
 

--- a/docs/04-java-client/12-retries.md
+++ b/docs/04-java-client/12-retries.md
@@ -10,6 +10,7 @@ keywords:
   - cadence backoff retry
   - cadence workflow retry
   - cadence java retry example
+  - cadence java retries tutorial
 permalink: /docs/java-client/retries
 ---
 

--- a/docs/04-java-client/13-child-workflows.md
+++ b/docs/04-java-client/13-child-workflows.md
@@ -11,6 +11,7 @@ keywords:
   - cadence java child workflow example
   - newChildWorkflowStub java
   - ParentClosePolicy java
+  - cadence java child workflows tutorial
 permalink: /docs/java-client/child-workflows
 ---
 

--- a/docs/04-java-client/14-exception-handling.md
+++ b/docs/04-java-client/14-exception-handling.md
@@ -10,6 +10,7 @@ keywords:
   - WorkflowFailureException java
   - cadence error handling java
   - cadence java exception example
+  - cadence java exception handling tutorial
 permalink: /docs/java-client/exception-handling
 ---
 

--- a/docs/04-java-client/15-continue-as-new.md
+++ b/docs/04-java-client/15-continue-as-new.md
@@ -10,6 +10,7 @@ keywords:
   - cadence workflow reset java
   - cadence periodic workflow java
   - cadence java continueAsNew example
+  - cadence java continue as new tutorial
 permalink: /docs/java-client/continue-as-new
 ---
 

--- a/docs/04-java-client/16-side-effect.md
+++ b/docs/04-java-client/16-side-effect.md
@@ -10,6 +10,7 @@ keywords:
   - cadence random number workflow
   - cadence sideEffect replay
   - cadence java side effect example
+  - cadence java side effect tutorial
 permalink: /docs/java-client/side-effect
 ---
 

--- a/docs/04-java-client/17-testing.md
+++ b/docs/04-java-client/17-testing.md
@@ -10,6 +10,7 @@ keywords:
   - cadence workflow test java
   - cadence activity test java
   - cadence java test example
+  - cadence java testing tutorial
 permalink: /docs/java-client/testing
 ---
 

--- a/docs/04-java-client/18-workflow-replay-shadowing.md
+++ b/docs/04-java-client/18-workflow-replay-shadowing.md
@@ -10,6 +10,7 @@ keywords:
   - cadence workflow versioning test
   - WorkflowReplayer java
   - cadence shadow test java
+  - cadence java workflow replay tutorial
 permalink: /docs/java-client/workflow-replay-shadowing
 ---
 

--- a/docs/05-go-client/01-workers.md
+++ b/docs/05-go-client/01-workers.md
@@ -14,6 +14,7 @@ keywords:
   - golang workflow engine
   - workflow engine go
   - embedded workflow engine go
+  - cadence go worker tutorial
 permalink: /docs/go-client/workers
 ---
 

--- a/docs/05-go-client/02-create-workflows.md
+++ b/docs/05-go-client/02-create-workflows.md
@@ -10,6 +10,7 @@ keywords:
   - cadence go workflow example
   - cadence workflow registration go
   - cadence go sdk workflow
+  - cadence go create workflow tutorial
 permalink: /docs/go-client/create-workflows
 ---
 

--- a/docs/05-go-client/03-starting-workflows.md
+++ b/docs/05-go-client/03-starting-workflows.md
@@ -10,6 +10,7 @@ keywords:
   - cadence go sdk start workflow
   - start workflow programmatically cadence
   - cadence go workflow trigger
+  - cadence go start workflow tutorial
 permalink: /docs/go-client/start-workflows
 ---
 

--- a/docs/05-go-client/04-activities.md
+++ b/docs/05-go-client/04-activities.md
@@ -10,6 +10,7 @@ keywords:
   - cadence go sdk activity
   - cadence activity context go
   - cadence activity example go
+  - cadence go activities tutorial
 permalink: /docs/go-client/activities
 ---
 

--- a/docs/05-go-client/05-execute-activity.md
+++ b/docs/05-go-client/05-execute-activity.md
@@ -10,6 +10,7 @@ keywords:
   - cadence go sdk execute activity
   - cadence activity scheduling go
   - cadence golang activity execution
+  - cadence go execute activity tutorial
 permalink: /docs/go-client/execute-activity
 ---
 

--- a/docs/05-go-client/06-child-workflows.md
+++ b/docs/05-go-client/06-child-workflows.md
@@ -11,6 +11,7 @@ keywords:
   - cadence golang child workflow example
   - ChildWorkflowOptions go
   - ParentClosePolicy go
+  - cadence go child workflows tutorial
 permalink: /docs/go-client/child-workflows
 ---
 

--- a/docs/05-go-client/07-retries.md
+++ b/docs/05-go-client/07-retries.md
@@ -12,6 +12,7 @@ keywords:
   - RetryPolicy
   - heartbeat progress
   - cadence go client
+  - cadence go retries tutorial
 permalink: /docs/go-client/retries
 ---
 

--- a/docs/05-go-client/08-error-handling.md
+++ b/docs/05-go-client/08-error-handling.md
@@ -12,6 +12,7 @@ keywords:
   - PanicError
   - CanceledError
   - go client error handling
+  - cadence go error handling tutorial
 permalink: /docs/go-client/error-handling
 ---
 

--- a/docs/05-go-client/09-signals.md
+++ b/docs/05-go-client/09-signals.md
@@ -11,6 +11,7 @@ keywords:
   - async workflow
   - go client signals
   - cadence go client
+  - cadence go signals tutorial
 permalink: /docs/go-client/signals
 ---
 

--- a/docs/05-go-client/10-continue-as-new.md
+++ b/docs/05-go-client/10-continue-as-new.md
@@ -10,6 +10,7 @@ keywords:
   - long running workflow
   - ContinueAsNewError
   - go client
+  - cadence go continue as new tutorial
 permalink: /docs/go-client/continue-as-new
 ---
 

--- a/docs/05-go-client/11-side-effect.md
+++ b/docs/05-go-client/11-side-effect.md
@@ -10,6 +10,7 @@ keywords:
   - random value workflow
   - go client side effect
   - inline activity
+  - cadence go side effect tutorial
 permalink: /docs/go-client/side-effect
 ---
 

--- a/docs/05-go-client/12-queries.md
+++ b/docs/05-go-client/12-queries.md
@@ -12,6 +12,7 @@ keywords:
   - __stack_trace
   - go client queries
   - QueryWorkflow
+  - cadence go queries tutorial
 permalink: /docs/go-client/queries
 ---
 

--- a/docs/05-go-client/13-activity-async-completion.md
+++ b/docs/05-go-client/13-activity-async-completion.md
@@ -10,6 +10,7 @@ keywords:
   - ErrResultPending
   - external activity completion
   - go client async activity
+  - cadence go async activity completion tutorial
 permalink: /docs/go-client/activity-async-completion
 ---
 

--- a/docs/05-go-client/14-workflow-testing.md
+++ b/docs/05-go-client/14-workflow-testing.md
@@ -11,6 +11,7 @@ keywords:
   - go client testing
   - cadence test suite
   - mock activity
+  - cadence go workflow testing tutorial
 permalink: /docs/go-client/workflow-testing
 ---
 

--- a/docs/05-go-client/15-workflow-versioning.md
+++ b/docs/05-go-client/15-workflow-versioning.md
@@ -12,6 +12,7 @@ keywords:
   - ExecuteWithMinVersion
   - ExecuteWithVersion
   - go client versioning
+  - cadence go workflow versioning tutorial
 permalink: /docs/go-client/workflow-versioning
 ---
 

--- a/docs/05-go-client/16-sessions.md
+++ b/docs/05-go-client/16-sessions.md
@@ -12,6 +12,7 @@ keywords:
   - concurrent session limit
   - file processing workflow
   - go client sessions
+  - cadence go sessions tutorial
 permalink: /docs/go-client/sessions
 ---
 

--- a/docs/05-go-client/17-distributed-cron.md
+++ b/docs/05-go-client/17-distributed-cron.md
@@ -12,6 +12,7 @@ keywords:
   - HasLastCompletionResult
   - GetLastCompletionResult
   - go client cron
+  - cadence go distributed cron tutorial
 permalink: /docs/go-client/distributed-cron
 ---
 

--- a/docs/05-go-client/18-tracing.md
+++ b/docs/05-go-client/18-tracing.md
@@ -12,6 +12,7 @@ keywords:
   - HeaderWriter
   - HeaderReader
   - go client tracing
+  - cadence go tracing tutorial
 permalink: /docs/go-client/tracing
 ---
 

--- a/docs/05-go-client/19-workflow-replay-shadowing.md
+++ b/docs/05-go-client/19-workflow-replay-shadowing.md
@@ -12,6 +12,7 @@ keywords:
   - NewWorkflowReplayer
   - shadow mode
   - go client replay
+  - cadence go workflow replay tutorial
 permalink: /docs/go-client/workflow-replay-shadowing
 ---
 

--- a/docs/05-go-client/20-workflow-non-deterministic-error.md
+++ b/docs/05-go-client/20-workflow-non-deterministic-error.md
@@ -12,6 +12,7 @@ keywords:
   - mismatched decisions
   - workflow code changes
   - go client non-deterministic
+  - cadence go non-deterministic error tutorial
 permalink: /docs/go-client/workflow-non-deterministic-error
 ---
 

--- a/docs/05-go-client/21-sleep.md
+++ b/docs/05-go-client/21-sleep.md
@@ -10,6 +10,7 @@ keywords:
   - pause workflow
   - workflow delay
   - go client sleep
+  - cadence go sleep tutorial
 permalink: /docs/go-client/sleep
 ---
 

--- a/docs/05-go-client/21-worker-auto-scaling.md
+++ b/docs/05-go-client/21-worker-auto-scaling.md
@@ -12,6 +12,7 @@ keywords:
   - worker auto scaling
   - go client autoscaler
   - dynamic poller management
+  - cadence go worker auto scaling tutorial
 permalink: /docs/go-client/worker-auto-scaling
 ---
 

--- a/docs/05-go-client/22-schedules.md
+++ b/docs/05-go-client/22-schedules.md
@@ -10,6 +10,7 @@ keywords:
   - cadence go overlap policy
   - cadence go backfill schedule
   - cadence go pause schedule
+  - cadence go schedules tutorial
 permalink: /docs/go-client/schedules
 ---
 

--- a/docs/07-python-client/01-workers.md
+++ b/docs/07-python-client/01-workers.md
@@ -7,6 +7,7 @@ keywords:
   - cadence python client setup
   - cadence python registry
   - cadence python task list
+  - cadence python workers tutorial
 permalink: /docs/python-client/workers
 ---
 

--- a/docs/07-python-client/02-workflows.md
+++ b/docs/07-python-client/02-workflows.md
@@ -8,6 +8,7 @@ keywords:
   - cadence python workflow.run
   - cadence python signal handler
   - cadence python query handler
+  - cadence python workflows tutorial
 permalink: /docs/python-client/workflows
 ---
 

--- a/docs/07-python-client/06-signals.md
+++ b/docs/07-python-client/06-signals.md
@@ -7,6 +7,7 @@ keywords:
   - cadence python signal handler
   - cadence python signal workflow
   - cadence python signal external workflow
+  - cadence python signals tutorial
 permalink: /docs/python-client/signals
 ---
 

--- a/docs/07-python-client/07-queries.md
+++ b/docs/07-python-client/07-queries.md
@@ -6,6 +6,7 @@ keywords:
   - cadence python query
   - cadence python query workflow
   - cadence python query handler
+  - cadence python queries tutorial
 permalink: /docs/python-client/queries
 ---
 

--- a/docs/07-python-client/11-distributed-cron.md
+++ b/docs/07-python-client/11-distributed-cron.md
@@ -6,6 +6,7 @@ keywords:
   - cadence python cron
   - cadence python distributed cron
   - cadence python recurring workflow
+  - cadence python distributed cron tutorial
 permalink: /docs/python-client/distributed-cron
 ---
 

--- a/docs/07-python-client/12-schedules.md
+++ b/docs/07-python-client/12-schedules.md
@@ -8,6 +8,7 @@ keywords:
   - cadence python recurring workflow
   - cadence python overlap policy
   - cadence python backfill schedule
+  - cadence python schedules tutorial
 permalink: /docs/python-client/schedules
 ---
 

--- a/docs/07-python-client/13-testing.md
+++ b/docs/07-python-client/13-testing.md
@@ -7,6 +7,7 @@ keywords:
   - cadence python workflow test
   - cadence python unit test
   - cadence python TestWorkflowEnvironment
+  - cadence python testing tutorial
 permalink: /docs/python-client/testing
 ---
 


### PR DESCRIPTION
**What changed?**

Added one `tutorial` SEO keyword to the frontmatter of the 67 doc pages that carry a Samples table, across use-cases, concepts, and the Go, Java, and Python client sections. One line added per file.

**Why?**

PR #402 gave these pages runnable samples, but nothing in their metadata signals that they are hands-on guides. er.

**How did you verify it?**

- Ran `npm run build`; succeeded with no new warnings.
- Confirmed scope with `git diff --numstat`: exactly 67 files, one insertion and zero deletions each, all 67 phrases unique.

**Potential risks**

N/A. Only changed frontmatter

**Related changes**

Follow-up to #402, which added the Samples tables these keywords describe.