### PR TITLE
docs: Add contributing guide and restructure README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Contributing to Cadence Docs
 
-Welcome, and thank you for helping improve the Cadence documentation. This repository is the source of [cadenceworkflow.io](https://cadenceworkflow.io), built with [Docusaurus](https://docusaurus.io/).
+Thanks for improving the Cadence documentation. This repository is the source of [cadenceworkflow.io](https://cadenceworkflow.io), built with [Docusaurus](https://docusaurus.io/).
 
-> 📚 **New to contributing to Cadence?** Check out our [Contributing Guide](https://cadenceworkflow.io/community/how-to-contribute/getting-started) for an overview of the contribution process across all Cadence repositories. This document contains setup and development instructions specific to the documentation site.
+> 📚 **New to contributing to Cadence?** See the [Contributing Guide](https://cadenceworkflow.io/community/how-to-contribute/getting-started) for how contributions work across Cadence repositories. This file covers setup and development for the docs site.
 
-Docs contributions are one of the most valuable things you can do for the project, and they are a great way to get started. If anything here does not make sense, or does not work when you run it, that is a bug in this guide. Please open an issue and tell us.
+Documentation patches help the project directly. They are also a good first contribution. If anything here does not make sense, or does not work when you run it, that is a bug in this guide. Please open an issue and tell us.
 
 - [Ways to contribute](#ways-to-contribute)
 - [Find an issue](#find-an-issue)
@@ -22,20 +22,20 @@ Docs contributions are one of the most valuable things you can do for the projec
 
 ## Ways to contribute
 
-Fixing a typo is a real contribution and you do not need permission to do it. Beyond that, we welcome:
+Fixing a typo counts, and you do not need permission. We also welcome the following contributions.
 
-- Corrections to anything inaccurate or out of date
-- Clarifying pages that confused you when you were learning Cadence
+- Fixes for inaccurate or outdated content
+- Clarifications to pages that confused you while learning Cadence
 - New guides, codelabs, FAQ entries, and blog posts
-- Improvements to site structure, navigation, and search
+- Changes to site structure, navigation, or search
 - Accessibility and rendering fixes
-- Reporting docs bugs you do not have time to fix yourself
+- Reports of docs bugs you cannot fix yourself
 
-For the full picture of contributor roles across the project, see [Ways to Contribute](https://cadenceworkflow.io/community/how-to-contribute/ways-to-contribute).
+For contributor roles across the project, see [Ways to Contribute](https://cadenceworkflow.io/community/how-to-contribute/ways-to-contribute).
 
 ## Find an issue
 
-Browse [open issues in this repository](https://github.com/cadence-workflow/Cadence-Docs/issues). Cadence aggregates many issues in the [main Cadence repository](https://github.com/cadence-workflow/cadence/issues), so it is worth checking there too, particularly the [good first issues](https://github.com/cadence-workflow/cadence/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22%20label%3Aup-for-grabs).
+Start with [open issues in this repository](https://github.com/cadence-workflow/Cadence-Docs/issues). Many Cadence issues live in the [main Cadence repository](https://github.com/cadence-workflow/cadence/issues), including [good first issues](https://github.com/cadence-workflow/cadence/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22%20label%3Aup-for-grabs). Check both before choosing work.
 
 Once you find something you want to work on, comment on the issue to say so. That prevents duplicated effort and gives maintainers a chance to add context before you start.
 
@@ -45,7 +45,7 @@ If you cannot find a suitable issue but you know something is wrong or missing, 
 
 The fastest way to reach maintainers is the **#cadence-contributors** channel on the CNCF Slack workspace. If you are not already a member, request an invite at [slack.cncf.io](https://slack.cncf.io/). Other ways to get in touch are listed on the [contact page](https://cadenceworkflow.io/community/contact-us).
 
-You can also comment on the issue or pull request you are working on. Asking early is encouraged, and a partially finished pull request is a perfectly good place to start a conversation.
+You can also comment on the issue or pull request you are working on. A draft pull request is a good place to ask questions.
 
 ## Development environment
 
@@ -64,13 +64,13 @@ If you use [direnv](https://direnv.net/), this repository ships an [`.envrc`](ht
 
 ### npm registry
 
-Make sure you have an [`.npmrc`](https://docs.npmjs.com/cli/v9/configuring-npm/npmrc/) configured with:
+Your [`.npmrc`](https://docs.npmjs.com/cli/v9/configuring-npm/npmrc/) should point to the public registry.
 
 ```
 registry=https://registry.npmjs.org/
 ```
 
-This ensures dependencies resolve from the public registry, and stops an internal corporate registry from leaking into `package-lock.json`.
+This keeps installs on the public registry and prevents a corporate registry from rewriting `package-lock.json`.
 
 ### Install dependencies
 
@@ -86,7 +86,7 @@ npm run start
 
 This starts the Docusaurus development server at http://localhost:3000/ and opens a browser window. Most edits appear immediately without a restart.
 
-The development server is the right tool while you are writing. It is *not* sufficient for verifying a change before you open a pull request, because it injects styles and serves content differently from the deployed site. See below.
+Use the development server while writing. Do not rely on it for pre-PR verification because it injects styles and serves content differently from the deployed site. See the verification steps below.
 
 ## Verify your change
 
@@ -98,7 +98,7 @@ Work through the steps that apply to your change. This is the same verification 
 npm run build
 ```
 
-Always run this. The build is your main safety net for links: [`docusaurus.config.ts`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/docusaurus.config.ts) sets both `onBrokenLinks: 'throw'` and `onBrokenMarkdownLinks: 'throw'`, so a broken internal link fails the build rather than shipping quietly. It also validates the featured carousel data described below.
+Run this every time. Broken internal links fail the build because [`docusaurus.config.ts`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/docusaurus.config.ts) sets both `onBrokenLinks: 'throw'` and `onBrokenMarkdownLinks: 'throw'`. The build also validates the featured carousel data described below.
 
 ### 2. Type-check, if you touched TypeScript
 
@@ -106,7 +106,7 @@ Always run this. The build is your main safety net for links: [`docusaurus.confi
 npm run typecheck
 ```
 
-Worth knowing: this is **not** part of CI today, so it only protects you if you run it. Use it whenever you change anything under `src/`, `docusaurus.config.ts`, or the sidebar files.
+This check is **not** part of CI today. Run it yourself whenever you change anything under `src/`, `docusaurus.config.ts`, or the sidebar files.
 
 ### 3. Preview the production build
 
@@ -136,7 +136,7 @@ For any change that affects rendering, check affected pages in both color modes 
 ## What CI runs on your pull request
 
 - **Build** ([`build.yml`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/.github/workflows/build.yml)) runs `npm ci && npm run build` on every push and pull request. This is the check that catches broken internal links.
-- **Link check** ([`link-check-pr.yml`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/.github/workflows/link-check-pr.yml)) runs [lychee](https://github.com/lycheeverse/lychee) against external `http(s)` links in the markdown files your pull request changed. Internal links are deliberately left to the build, which understands Docusaurus routing. This check is currently advisory: it reports failures but does not block merging. That is temporary, so please read its output and fix genuinely broken links rather than ignoring it.
+- **Link check** ([`link-check-pr.yml`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/.github/workflows/link-check-pr.yml)) runs [lychee](https://github.com/lycheeverse/lychee) against external `http(s)` links in the markdown files your pull request changed. Internal links are deliberately left to the build, which understands Docusaurus routing. This check is advisory for now. It reports failures but does not block merging. That will change, so read the output and fix broken links instead of ignoring failures.
 - **DCO** verifies every commit is signed off. See below.
 
 Maintainers must approve workflow runs for first-time contributors, so your checks may sit idle briefly before they start.
@@ -168,7 +168,7 @@ fix(carousel): Correct fallback image for video items
 
 Most changes here use the `docs` type. Full conventions, including the type list, are documented in [Pull Request Conventions](https://cadenceworkflow.io/community/how-to-contribute/pull-request-conventions).
 
-Write the pull request description for a maintainer reading it a year from now. Explain what changed and, more importantly, why: what was wrong or unclear before. See [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for the underlying habit. The [pull request template](https://github.com/cadence-workflow/Cadence-Docs/blob/master/.github/pull_request_template.md) prompts you for each part, and [`.github/pull_request_guidance.md`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/.github/pull_request_guidance.md) has worked examples of good and bad answers.
+Write the pull request description for a maintainer reading it a year from now. State what changed and why the old text or behavior was wrong or unclear. See [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for the underlying habit. The [pull request template](https://github.com/cadence-workflow/Cadence-Docs/blob/master/.github/pull_request_template.md) prompts you for each part, and [`.github/pull_request_guidance.md`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/.github/pull_request_guidance.md) has worked examples of good and bad answers.
 
 Before you submit, confirm that you have:
 
@@ -179,7 +179,7 @@ Before you submit, confirm that you have:
 - [ ] Signed every commit with `-s`
 - [ ] Noted any moved or renamed page so a redirect can be added
 
-Two maintainer approvals are required to merge. Expect review comments on everything, from anyone; that is normal and not a judgment of your work. Comments prefixed with `nit:` are stylistic preferences that do not block merging.
+Merging requires two maintainer approvals. Review comments can come from anyone and are a normal part of the process. Comments prefixed with `nit:` are style suggestions and do not block merging.
 
 ## Common documentation tasks
 
@@ -187,7 +187,7 @@ Two maintainer approvals are required to merge. Expect review comments on everyt
 
 Documentation lives under `docs/`, organized into numbered directories and files such as `docs/05-go-client/23-batch-future.md`. The numeric prefixes control ordering only; Docusaurus strips them from the published URL, so that file is served at `/docs/go-client/batch-future`.
 
-Two things catch people out:
+New contributors often miss two steps.
 
 - **Sidebars are explicit, not generated.** [`sidebars.ts`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/sidebars.ts) lists every page by ID, and the filesystem-autogenerated option is deliberately commented out. A new page will build fine and be reachable by URL, but it will not appear in the sidebar until you add it to the right category. The community and FAQ sections have their own files, [`sidebarsCommunity.js`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/sidebarsCommunity.js) and [`sidebarsFAQ.js`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/sidebarsFAQ.js).
 - **Moved or renamed pages need a redirect.** Add an entry to the `plugin-client-redirects` configuration in [`docusaurus.config.ts`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/docusaurus.config.ts) so existing links and search results keep working. Redirects only take effect in a production build, so `npm run start` will not show them. Verify them with the production preview.
@@ -196,7 +196,7 @@ Two things catch people out:
 
 The homepage "Featured reading" carousel is driven entirely by [`src/data/featuredLinks.yaml`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/src/data/featuredLinks.yaml). No code changes are needed to add, remove, or reorder items. Items render in the order they appear in the file, so add a new entry wherever it should show up.
 
-Each entry supports:
+Each YAML entry may include the following fields.
 
 - `title` (required): Card headline.
 - `description` (required): One or two short sentences.
@@ -223,11 +223,11 @@ Normally you do not need to. The `fetch-release-data` GitHub Action checks for n
 
 ## Publish a personal GitHub Pages preview
 
-Optional, and only useful for larger changes. You can deploy your fork to your own GitHub Pages site, giving you a shareable URL such as `https://<your-username>.github.io/Cadence-Docs/`.
+This step is optional. Use it for larger changes. You can deploy your fork to your own GitHub Pages site, giving you a shareable URL such as `https://<your-username>.github.io/Cadence-Docs/`.
 
-This is worth doing when a local preview is not enough:
+Consider a fork deployment when a local preview is not enough.
 
-- You want to share a rendered page with a reviewer, or gather feedback before opening a pull request.
+- Share a rendered page with a reviewer or get feedback before opening a pull request.
 - Your change touches links or assets, and you need to catch paths that break when the site is served from a subpath rather than the domain root. `npm run start` serves from `/`, so it never exercises this. The canonical site also runs at `/`, but a fork's project site runs under `/Cadence-Docs/`.
 
 Note that a fork deploys with `BASE_URL=/Cadence-Docs/` and no custom domain. Do not set `CUSTOM_DOMAIN` or commit a `static/CNAME` file on your fork; those exist for the canonical cadenceworkflow.io deployment only, and setting them on a fork will send your preview to the wrong hostname.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,246 @@
+# Contributing to Cadence Docs
+
+Welcome, and thank you for helping improve the Cadence documentation. This repository is the source of [cadenceworkflow.io](https://cadenceworkflow.io), built with [Docusaurus](https://docusaurus.io/).
+
+> 📚 **New to contributing to Cadence?** Check out our [Contributing Guide](https://cadenceworkflow.io/community/how-to-contribute/getting-started) for an overview of the contribution process across all Cadence repositories. This document contains setup and development instructions specific to the documentation site.
+
+Docs contributions are one of the most valuable things you can do for the project, and they are a great way to get started. If anything here does not make sense, or does not work when you run it, that is a bug in this guide. Please open an issue and tell us.
+
+- [Ways to contribute](#ways-to-contribute)
+- [Find an issue](#find-an-issue)
+- [Ask for help](#ask-for-help)
+- [Development environment](#development-environment)
+- [Run the site locally](#run-the-site-locally)
+- [Verify your change](#verify-your-change)
+- [What CI runs on your pull request](#what-ci-runs-on-your-pull-request)
+- [Sign your commits](#sign-your-commits)
+- [Pull request conventions](#pull-request-conventions)
+- [Common documentation tasks](#common-documentation-tasks)
+- [Publish a personal GitHub Pages preview](#publish-a-personal-github-pages-preview)
+- [Code of Conduct](#code-of-conduct)
+- [License](#license)
+
+## Ways to contribute
+
+Fixing a typo is a real contribution and you do not need permission to do it. Beyond that, we welcome:
+
+- Corrections to anything inaccurate or out of date
+- Clarifying pages that confused you when you were learning Cadence
+- New guides, codelabs, FAQ entries, and blog posts
+- Improvements to site structure, navigation, and search
+- Accessibility and rendering fixes
+- Reporting docs bugs you do not have time to fix yourself
+
+For the full picture of contributor roles across the project, see [Ways to Contribute](https://cadenceworkflow.io/community/how-to-contribute/ways-to-contribute).
+
+## Find an issue
+
+Browse [open issues in this repository](https://github.com/cadence-workflow/Cadence-Docs/issues). Cadence aggregates many issues in the [main Cadence repository](https://github.com/cadence-workflow/cadence/issues), so it is worth checking there too, particularly the [good first issues](https://github.com/cadence-workflow/cadence/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22%20label%3Aup-for-grabs).
+
+Once you find something you want to work on, comment on the issue to say so. That prevents duplicated effort and gives maintainers a chance to add context before you start.
+
+If you cannot find a suitable issue but you know something is wrong or missing, open a new issue describing the problem. You do not need to have the fix ready.
+
+## Ask for help
+
+The fastest way to reach maintainers is the **#cadence-contributors** channel on the CNCF Slack workspace. If you are not already a member, request an invite at [slack.cncf.io](https://slack.cncf.io/). Other ways to get in touch are listed on the [contact page](https://cadenceworkflow.io/community/contact-us).
+
+You can also comment on the issue or pull request you are working on. Asking early is encouraged, and a partially finished pull request is a perfectly good place to start a conversation.
+
+## Development environment
+
+### Node.js
+
+This site requires **Node.js 22 or newer**. The version is pinned in [`.nvmrc`](.nvmrc) and [`.node-version`](.node-version), and enforced by the `engines` field in [`package.json`](package.json). CI builds on the current Node 22 LTS release.
+
+If you use [nvm](https://github.com/nvm-sh/nvm):
+
+```console
+nvm install
+nvm use
+```
+
+If you use [direnv](https://direnv.net/), this repository ships an [`.envrc`](.envrc) that selects the pinned Node version for you and sets `NODE_OPTIONS=--openssl-legacy-provider`, which some dependencies still need. Put any personal environment overrides in `.envrc.local`, which is loaded automatically and is not tracked by git.
+
+### npm registry
+
+Make sure you have an [`.npmrc`](https://docs.npmjs.com/cli/v9/configuring-npm/npmrc/) configured with:
+
+```
+registry=https://registry.npmjs.org/
+```
+
+This ensures dependencies resolve from the public registry, and stops an internal corporate registry from leaking into `package-lock.json`.
+
+### Install dependencies
+
+```console
+npm install
+```
+
+## Run the site locally
+
+```console
+npm run start
+```
+
+This starts the Docusaurus development server at http://localhost:3000/ and opens a browser window. Most edits appear immediately without a restart.
+
+The development server is the right tool while you are writing. It is *not* sufficient for verifying a change before you open a pull request, because it injects styles and serves content differently from the deployed site. See below.
+
+## Verify your change
+
+Work through the steps that apply to your change. This is the same verification the [pull request template](.github/pull_request_template.md) asks you to describe, and the detailed rules live in [`.github/pull_request_guidance.md`](.github/pull_request_guidance.md).
+
+### 1. Build the site
+
+```console
+npm run build
+```
+
+Always run this. The build is your main safety net for links: [`docusaurus.config.ts`](docusaurus.config.ts) sets both `onBrokenLinks: 'throw'` and `onBrokenMarkdownLinks: 'throw'`, so a broken internal link fails the build rather than shipping quietly. It also validates the featured carousel data described below.
+
+### 2. Type-check, if you touched TypeScript
+
+```console
+npm run typecheck
+```
+
+Worth knowing: this is **not** part of CI today, so it only protects you if you run it. Use it whenever you change anything under `src/`, `docusaurus.config.ts`, or the sidebar files.
+
+### 3. Preview the production build
+
+```console
+npm run preview:github-pages -- --serve
+```
+
+Then open http://localhost:4173/.
+
+This produces the same static HTML that GitHub Pages serves, copies it into the gitignored `.preview-pages/` directory, and serves it without single-page-app fallback so that redirects and 404s behave the way they will in production. It runs `npm ci` and a full build, so expect it to take longer than `npm run start`.
+
+You can also invoke the script directly, which requires making it executable once:
+
+```console
+chmod +x scripts/preview-github-pages-build.sh
+./scripts/preview-github-pages-build.sh --serve
+```
+
+The script accepts `PORT`, `PREVIEW_DIR`, `BASE_URL`, and `CADENCE_DOCS_URL` as environment variables.
+
+**The production preview is required for any change beyond prose edits in `.md` files.** That includes `.mdx`, `docusaurus.config.*`, `sidebars.*`, anything under `src/`, non-markdown files under `static/`, CSS or SCSS, scripts, and package files. Pull requests that need it and do not mention it will be sent back.
+
+### 4. Check dark mode and light mode
+
+For any change that affects rendering, check affected pages in both color modes using the theme toggle in the site header.
+
+## What CI runs on your pull request
+
+- **Build** ([`build.yml`](.github/workflows/build.yml)) runs `npm ci && npm run build` on every push and pull request. This is the check that catches broken internal links.
+- **Link check** ([`link-check-pr.yml`](.github/workflows/link-check-pr.yml)) runs [lychee](https://github.com/lycheeverse/lychee) against external `http(s)` links in the markdown files your pull request changed. Internal links are deliberately left to the build, which understands Docusaurus routing. This check is currently advisory: it reports failures but does not block merging. That is temporary, so please read its output and fix genuinely broken links rather than ignoring it.
+- **DCO** verifies every commit is signed off. See below.
+
+Maintainers must approve workflow runs for first-time contributors, so your checks may sit idle briefly before they start.
+
+## Sign your commits
+
+Cadence uses the [Developer Certificate of Origin](https://developercertificate.org/) (DCO), not a CLA. Every commit must carry a `Signed-off-by` line matching the author's name and email:
+
+```console
+git commit -s -m "Your commit message"
+```
+
+Sign-off is required for everyone, including maintainers. If you forget on a commit you have not pushed yet:
+
+```console
+git commit --amend -s --no-edit
+```
+
+GPG signing satisfies the check as well. Setup instructions for both approaches are in [Pull Request Conventions](https://cadenceworkflow.io/community/how-to-contribute/pull-request-conventions).
+
+## Pull request conventions
+
+Pull request titles follow [Conventional Commits](https://www.conventionalcommits.org/), start with an uppercase letter, and use the imperative mood:
+
+```
+docs: Clarify memo versus search attributes
+fix(carousel): Correct fallback image for video items
+```
+
+Most changes here use the `docs` type. Full conventions, including the type list, are documented in [Pull Request Conventions](https://cadenceworkflow.io/community/how-to-contribute/pull-request-conventions).
+
+Write the pull request description for a maintainer reading it a year from now. Explain what changed and, more importantly, why: what was wrong or unclear before. See [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for the underlying habit. The [pull request template](.github/pull_request_template.md) prompts you for each part, and [`.github/pull_request_guidance.md`](.github/pull_request_guidance.md) has worked examples of good and bad answers.
+
+Before you submit, confirm that you have:
+
+- [ ] Run `npm run build` successfully
+- [ ] Run the production preview if your change is anything beyond prose in a `.md` file
+- [ ] Checked affected pages in dark mode and light mode
+- [ ] Listed the specific pages you verified, in the description
+- [ ] Signed every commit with `-s`
+- [ ] Noted any moved or renamed page so a redirect can be added
+
+Two maintainer approvals are required to merge. Expect review comments on everything, from anyone; that is normal and not a judgment of your work. Comments prefixed with `nit:` are stylistic preferences that do not block merging.
+
+## Common documentation tasks
+
+### Adding, moving, or renaming a page
+
+Documentation lives under `docs/`, organized into numbered directories and files such as `docs/05-go-client/23-batch-future.md`. The numeric prefixes control ordering only; Docusaurus strips them from the published URL, so that file is served at `/docs/go-client/batch-future`.
+
+Two things catch people out:
+
+- **Sidebars are explicit, not generated.** [`sidebars.ts`](sidebars.ts) lists every page by ID, and the filesystem-autogenerated option is deliberately commented out. A new page will build fine and be reachable by URL, but it will not appear in the sidebar until you add it to the right category. The community and FAQ sections have their own files, [`sidebarsCommunity.js`](sidebarsCommunity.js) and [`sidebarsFAQ.js`](sidebarsFAQ.js).
+- **Moved or renamed pages need a redirect.** Add an entry to the `plugin-client-redirects` configuration in [`docusaurus.config.ts`](docusaurus.config.ts) so existing links and search results keep working. Redirects only take effect in a production build, so `npm run start` will not show them. Verify them with the production preview.
+
+### Updating the featured reading carousel
+
+The homepage "Featured reading" carousel is driven entirely by [`src/data/featuredLinks.yaml`](src/data/featuredLinks.yaml). No code changes are needed to add, remove, or reorder items. Items render in the order they appear in the file, so add a new entry wherever it should show up.
+
+Each entry supports:
+
+- `title` (required): Card headline.
+- `description` (required): One or two short sentences.
+- `href` (required): Internal route (e.g. `/docs/...`) or a full external URL.
+- `tag` (required): One of `Blog`, `Doc`, `Community`, `FAQ`, `Video`, defined in [`src/data/featuredTags.ts`](src/data/featuredTags.ts). An unrecognized tag fails the build with a clear error.
+- `image` (optional): Overrides the tag's default image. A path under `static/` (e.g. `/img/foo.png`) or a full URL.
+- `cta` (optional): Call-to-action label; defaults to "Read more".
+
+```yaml
+- title: "Introducing Cadence Schedules"
+  description: Cadence Schedules bring first-class recurring workflow execution to the platform.
+  href: /blog/2026/06/23/cadence-schedules
+  tag: Blog
+  cta: Read post
+```
+
+For `Video` items linking to YouTube, the carousel automatically pulls the video's thumbnail as the card image, falling back to the tag's default image if the thumbnail fails to load.
+
+### Updating release data
+
+The release pages read from JSON files under `static/data/releases/`. To refresh them manually, run `scripts/fetch-releases.sh`, which uses the [GitHub CLI](https://cli.github.com/).
+
+Normally you do not need to. The `fetch-release-data` GitHub Action checks for new release data, and when it finds some, pushes a `fetch-release-data` branch and opens a pull request if one is not already open. Those pull requests need manual approval before merging.
+
+## Publish a personal GitHub Pages preview
+
+Optional, and only useful for larger changes. You can deploy your fork to your own GitHub Pages site, giving you a shareable URL such as `https://<your-username>.github.io/Cadence-Docs/`.
+
+This is worth doing when a local preview is not enough:
+
+- You want to share a rendered page with a reviewer, or gather feedback before opening a pull request.
+- Your change touches links or assets, and you need to catch paths that break when the site is served from a subpath rather than the domain root. `npm run start` serves from `/`, so it never exercises this. The canonical site also runs at `/`, but a fork's project site runs under `/Cadence-Docs/`.
+
+Note that a fork deploys with `BASE_URL=/Cadence-Docs/` and no custom domain. Do not set `CUSTOM_DOMAIN` or commit a `static/CNAME` file on your fork; those exist for the canonical cadenceworkflow.io deployment only, and setting them on a fork will send your preview to the wrong hostname.
+
+<!-- TODO: Paste the step-by-step personal GitHub Pages setup here.
+     Should cover: forking, enabling GitHub Pages on the fork, the repo
+     variables to set (BASE_URL, ORGANIZATION_NAME, CADENCE_DOCS_URL),
+     triggering the deploy workflow, and how to confirm the site is live. -->
+
+## Code of Conduct
+
+Cadence follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md). By participating you agree to uphold it. Report unacceptable behavior to the [CNCF Code of Conduct Committee](mailto:conduct@cncf.io).
+
+## License
+
+By contributing, you agree that your contributions are licensed under this repository's terms: source code under the Apache License 2.0, and documentation content under the Creative Commons Attribution 4.0 International License. See [LICENSE.md](LICENSE.md) for details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ You can also comment on the issue or pull request you are working on. Asking ear
 
 ### Node.js
 
-This site requires **Node.js 22 or newer**. The version is pinned in [`.nvmrc`](.nvmrc) and [`.node-version`](.node-version), and enforced by the `engines` field in [`package.json`](package.json). CI builds on the current Node 22 LTS release.
+This site requires **Node.js 22 or newer**. The version is pinned in [`.nvmrc`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/.nvmrc) and [`.node-version`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/.node-version), and enforced by the `engines` field in [`package.json`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/package.json). CI builds on the current Node 22 LTS release.
 
 If you use [nvm](https://github.com/nvm-sh/nvm):
 
@@ -60,7 +60,7 @@ nvm install
 nvm use
 ```
 
-If you use [direnv](https://direnv.net/), this repository ships an [`.envrc`](.envrc) that selects the pinned Node version for you and sets `NODE_OPTIONS=--openssl-legacy-provider`, which some dependencies still need. Put any personal environment overrides in `.envrc.local`, which is loaded automatically and is not tracked by git.
+If you use [direnv](https://direnv.net/), this repository ships an [`.envrc`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/.envrc) that selects the pinned Node version for you and sets `NODE_OPTIONS=--openssl-legacy-provider`, which some dependencies still need. Put any personal environment overrides in `.envrc.local`, which is loaded automatically and is not tracked by git.
 
 ### npm registry
 
@@ -90,7 +90,7 @@ The development server is the right tool while you are writing. It is *not* suff
 
 ## Verify your change
 
-Work through the steps that apply to your change. This is the same verification the [pull request template](.github/pull_request_template.md) asks you to describe, and the detailed rules live in [`.github/pull_request_guidance.md`](.github/pull_request_guidance.md).
+Work through the steps that apply to your change. This is the same verification the [pull request template](https://github.com/cadence-workflow/Cadence-Docs/blob/master/.github/pull_request_template.md) asks you to describe, and the detailed rules live in [`.github/pull_request_guidance.md`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/.github/pull_request_guidance.md).
 
 ### 1. Build the site
 
@@ -98,7 +98,7 @@ Work through the steps that apply to your change. This is the same verification 
 npm run build
 ```
 
-Always run this. The build is your main safety net for links: [`docusaurus.config.ts`](docusaurus.config.ts) sets both `onBrokenLinks: 'throw'` and `onBrokenMarkdownLinks: 'throw'`, so a broken internal link fails the build rather than shipping quietly. It also validates the featured carousel data described below.
+Always run this. The build is your main safety net for links: [`docusaurus.config.ts`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/docusaurus.config.ts) sets both `onBrokenLinks: 'throw'` and `onBrokenMarkdownLinks: 'throw'`, so a broken internal link fails the build rather than shipping quietly. It also validates the featured carousel data described below.
 
 ### 2. Type-check, if you touched TypeScript
 
@@ -135,8 +135,8 @@ For any change that affects rendering, check affected pages in both color modes 
 
 ## What CI runs on your pull request
 
-- **Build** ([`build.yml`](.github/workflows/build.yml)) runs `npm ci && npm run build` on every push and pull request. This is the check that catches broken internal links.
-- **Link check** ([`link-check-pr.yml`](.github/workflows/link-check-pr.yml)) runs [lychee](https://github.com/lycheeverse/lychee) against external `http(s)` links in the markdown files your pull request changed. Internal links are deliberately left to the build, which understands Docusaurus routing. This check is currently advisory: it reports failures but does not block merging. That is temporary, so please read its output and fix genuinely broken links rather than ignoring it.
+- **Build** ([`build.yml`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/.github/workflows/build.yml)) runs `npm ci && npm run build` on every push and pull request. This is the check that catches broken internal links.
+- **Link check** ([`link-check-pr.yml`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/.github/workflows/link-check-pr.yml)) runs [lychee](https://github.com/lycheeverse/lychee) against external `http(s)` links in the markdown files your pull request changed. Internal links are deliberately left to the build, which understands Docusaurus routing. This check is currently advisory: it reports failures but does not block merging. That is temporary, so please read its output and fix genuinely broken links rather than ignoring it.
 - **DCO** verifies every commit is signed off. See below.
 
 Maintainers must approve workflow runs for first-time contributors, so your checks may sit idle briefly before they start.
@@ -168,7 +168,7 @@ fix(carousel): Correct fallback image for video items
 
 Most changes here use the `docs` type. Full conventions, including the type list, are documented in [Pull Request Conventions](https://cadenceworkflow.io/community/how-to-contribute/pull-request-conventions).
 
-Write the pull request description for a maintainer reading it a year from now. Explain what changed and, more importantly, why: what was wrong or unclear before. See [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for the underlying habit. The [pull request template](.github/pull_request_template.md) prompts you for each part, and [`.github/pull_request_guidance.md`](.github/pull_request_guidance.md) has worked examples of good and bad answers.
+Write the pull request description for a maintainer reading it a year from now. Explain what changed and, more importantly, why: what was wrong or unclear before. See [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for the underlying habit. The [pull request template](https://github.com/cadence-workflow/Cadence-Docs/blob/master/.github/pull_request_template.md) prompts you for each part, and [`.github/pull_request_guidance.md`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/.github/pull_request_guidance.md) has worked examples of good and bad answers.
 
 Before you submit, confirm that you have:
 
@@ -189,19 +189,19 @@ Documentation lives under `docs/`, organized into numbered directories and files
 
 Two things catch people out:
 
-- **Sidebars are explicit, not generated.** [`sidebars.ts`](sidebars.ts) lists every page by ID, and the filesystem-autogenerated option is deliberately commented out. A new page will build fine and be reachable by URL, but it will not appear in the sidebar until you add it to the right category. The community and FAQ sections have their own files, [`sidebarsCommunity.js`](sidebarsCommunity.js) and [`sidebarsFAQ.js`](sidebarsFAQ.js).
-- **Moved or renamed pages need a redirect.** Add an entry to the `plugin-client-redirects` configuration in [`docusaurus.config.ts`](docusaurus.config.ts) so existing links and search results keep working. Redirects only take effect in a production build, so `npm run start` will not show them. Verify them with the production preview.
+- **Sidebars are explicit, not generated.** [`sidebars.ts`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/sidebars.ts) lists every page by ID, and the filesystem-autogenerated option is deliberately commented out. A new page will build fine and be reachable by URL, but it will not appear in the sidebar until you add it to the right category. The community and FAQ sections have their own files, [`sidebarsCommunity.js`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/sidebarsCommunity.js) and [`sidebarsFAQ.js`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/sidebarsFAQ.js).
+- **Moved or renamed pages need a redirect.** Add an entry to the `plugin-client-redirects` configuration in [`docusaurus.config.ts`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/docusaurus.config.ts) so existing links and search results keep working. Redirects only take effect in a production build, so `npm run start` will not show them. Verify them with the production preview.
 
 ### Updating the featured reading carousel
 
-The homepage "Featured reading" carousel is driven entirely by [`src/data/featuredLinks.yaml`](src/data/featuredLinks.yaml). No code changes are needed to add, remove, or reorder items. Items render in the order they appear in the file, so add a new entry wherever it should show up.
+The homepage "Featured reading" carousel is driven entirely by [`src/data/featuredLinks.yaml`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/src/data/featuredLinks.yaml). No code changes are needed to add, remove, or reorder items. Items render in the order they appear in the file, so add a new entry wherever it should show up.
 
 Each entry supports:
 
 - `title` (required): Card headline.
 - `description` (required): One or two short sentences.
 - `href` (required): Internal route (e.g. `/docs/...`) or a full external URL.
-- `tag` (required): One of `Blog`, `Doc`, `Community`, `FAQ`, `Video`, defined in [`src/data/featuredTags.ts`](src/data/featuredTags.ts). An unrecognized tag fails the build with a clear error.
+- `tag` (required): One of `Blog`, `Doc`, `Community`, `FAQ`, `Video`, defined in [`src/data/featuredTags.ts`](https://github.com/cadence-workflow/Cadence-Docs/blob/master/src/data/featuredTags.ts). An unrecognized tag fails the build with a clear error.
 - `image` (optional): Overrides the tag's default image. A path under `static/` (e.g. `/img/foo.png`) or a full URL.
 - `cta` (optional): Call-to-action label; defaults to "Read more".
 
@@ -243,4 +243,4 @@ Cadence follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/bl
 
 ## License
 
-By contributing, you agree that your contributions are licensed under this repository's terms: source code under the Apache License 2.0, and documentation content under the Creative Commons Attribution 4.0 International License. See [LICENSE.md](LICENSE.md) for details.
+By contributing, you agree that your contributions are licensed under this repository's terms: source code under the Apache License 2.0, and documentation content under the Creative Commons Attribution 4.0 International License. See [LICENSE.md](https://github.com/cadence-workflow/Cadence-Docs/blob/master/LICENSE.md) for details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,17 +225,26 @@ Normally you do not need to. The `fetch-release-data` GitHub Action checks for n
 
 This step is optional. Use it for larger changes. You can deploy your fork to your own GitHub Pages site, giving you a shareable URL such as `https://<your-username>.github.io/Cadence-Docs/`.
 
-Consider a fork deployment when a local preview is not enough.
+**Deploy a branch**
 
-- Share a rendered page with a reviewer or get feedback before opening a pull request.
-- Your change touches links or assets, and you need to catch paths that break when the site is served from a subpath rather than the domain root. `npm run start` serves from `/`, so it never exercises this. The canonical site also runs at `/`, but a fork's project site runs under `/Cadence-Docs/`.
+1. In your fork, open the Actions tab. The first time, click "I understand my workflows, go ahead and enable them".
+2. Select the "Build and Deploy" workflow.
+3. Run workflow, choose your branch, then Run workflow.
+4. Wait 1 to 2 minutes for it to finish.
+5. Open `https://<your-username>.github.io/Cadence-Docs/`.
 
-Note that a fork deploys with `BASE_URL=/Cadence-Docs/` and no custom domain. Do not set `CUSTOM_DOMAIN` or commit a `static/CNAME` file on your fork; those exist for the canonical cadenceworkflow.io deployment only, and setting them on a fork will send your preview to the wrong hostname.
+**One-time setup, after your first deploy**
 
-<!-- TODO: Paste the step-by-step personal GitHub Pages setup here.
-     Should cover: forking, enabling GitHub Pages on the fork, the repo
-     variables to set (BASE_URL, ORGANIZATION_NAME, CADENCE_DOCS_URL),
-     triggering the deploy workflow, and how to confirm the site is live. -->
+1. In your fork, go to Settings, then Pages.
+2. Under Build and deployment, set Source to "Deploy from a branch".
+3. Set Branch to `gh-pages` and Folder to `/ (root)`, then Save.
+
+The first deploy creates the `gh-pages` branch, which is why this comes second.
+
+**Good to know**
+
+- Pushing to master auto-deploys. Any other branch must be run manually.
+- It's one live site; each run replaces what was there before.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Build and Deploy](https://img.shields.io/github/actions/workflow/status/cadence-workflow/Cadence-Docs/publish-to-gh-pages.yml?label=Build%20and%20Deploy)](https://github.com/cadence-workflow/Cadence-Docs/actions/workflows/publish-to-gh-pages.yml)
 [![Nightly integration test](https://img.shields.io/github/actions/workflow/status/cadence-workflow/Cadence-Docs/nightly-integration-test.yml?label=Nightly%20integration%20test)](https://github.com/cadence-workflow/Cadence-Docs/actions/workflows/nightly-integration-test.yml)
 
-This repository is the source of [cadenceworkflow.io](https://cadenceworkflow.io), the documentation site for [Cadence](https://github.com/cadence-workflow/cadence). It is built with [Docusaurus](https://docusaurus.io/).
+[cadenceworkflow.io](https://cadenceworkflow.io) is the documentation site for [Cadence](https://github.com/cadence-workflow/cadence). This repository contains its [Docusaurus](https://docusaurus.io/) source.
 
-> 📚 **New to contributing to Cadence?** Check out our [Contributing Guide](https://cadenceworkflow.io/community/how-to-contribute/getting-started) for an overview of the contribution process across all Cadence repositories. For setup and development instructions specific to this site, see [CONTRIBUTING.md](CONTRIBUTING.md).
+> 📚 **Contributing to Cadence?** The [Contributing Guide](https://cadenceworkflow.io/community/how-to-contribute/getting-started) covers the project-wide process. For site setup and development, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Quick start
 
@@ -16,27 +16,27 @@ npm install
 npm run start
 ```
 
-This starts a local development server at http://localhost:3000/ and opens a browser window. Most changes are reflected live without restarting the server.
+The development server runs at http://localhost:3000/ and opens a browser window. Most edits reload without a restart.
 
-To generate the static site into the `build` directory, which can be served by any static host:
+To write the static site to `build/` for any static host, run:
 
 ```console
 npm run build
 ```
 
-[CONTRIBUTING.md](CONTRIBUTING.md) covers the rest: Node version pinning, npm registry configuration, the production preview you should run before opening a pull request, and how to add or move a page.
+[CONTRIBUTING.md](CONTRIBUTING.md) also covers Node version pinning, npm registry setup, running a production preview before you open a pull request, and adding or moving pages.
 
 ## How the site is deployed
 
 The live site is published by the **Build and Deploy** workflow ([`publish-to-gh-pages.yml`](.github/workflows/publish-to-gh-pages.yml)), which runs on every push to `master` and can also be triggered manually. It builds with `npm ci && npm run build`, deploys the `build` directory to the `gh-pages` branch, and then asks the Algolia crawler to re-index the site.
 
-`npm run deploy` also exists as a manual fallback that builds and pushes to `gh-pages` from your machine, using either `USE_SSH=true npm run deploy` or `GIT_USER=<your GitHub username> npm run deploy`. Day to day you should not need it; prefer letting the workflow deploy.
+You can also run `npm run deploy` locally to build and push to `gh-pages`, using either `USE_SSH=true npm run deploy` or `GIT_USER=<your GitHub username> npm run deploy`. In normal use, let the workflow handle deployment.
 
 ### Configuration
 
-A few options in [`docusaurus.config.ts`](docusaurus.config.ts) can be overridden by environment variables so the site can be deployed to more than one place. The deploy workflow reads them from the repository's `production` environment settings.
+Environment variables can override selected settings in [`docusaurus.config.ts`](docusaurus.config.ts) for other deployment targets. The workflow reads them from the repository's `production` environment.
 
-The canonical cadenceworkflow.io deployment uses:
+For cadenceworkflow.io, set:
 
 ```bash
 # Site origin, used to build absolute URLs.
@@ -49,17 +49,17 @@ BASE_URL=/
 ORGANIZATION_NAME=cadence-workflow
 ```
 
-If a variable is not set, the workflow derives a sensible default from the repository name, so a fork deploys to `/<repo>/` without any configuration. Deploying your own fork for preview purposes is documented in [CONTRIBUTING.md](CONTRIBUTING.md); the values above are for the canonical site and should not be copied to a fork.
+When a variable is unset, the workflow uses defaults based on the repository name, so a fork deploys to `/<repo>/` with no extra configuration. Fork preview setup is documented in [CONTRIBUTING.md](CONTRIBUTING.md). The values above apply only to cadenceworkflow.io and should not be copied to a fork.
 
 ### Custom domain
 
-Serving the site from a [custom domain](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site) such as cadenceworkflow.io requires a `static/CNAME` file, because anything under `static/` is copied to the root of the build output. The file is not committed: the deploy workflow creates it from the `CUSTOM_DOMAIN` secret. Forks have no such secret and therefore no custom domain, which is the intended behavior.
+A [custom domain](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site) such as cadenceworkflow.io needs a `static/CNAME` file. Content under `static/` is copied to the build root, placing that file at the site root. The file is not committed; the deploy workflow writes it from the `CUSTOM_DOMAIN` secret. Forks do not have that secret or a custom domain.
 
 ## Contributing
 
-Documentation contributions are welcome and are a good way to get started with the project. Start with [CONTRIBUTING.md](CONTRIBUTING.md) for how to set up, verify, and submit a change to this site.
+Documentation changes are welcome. [CONTRIBUTING.md](CONTRIBUTING.md) explains how to set up the site locally, verify your work, and open a pull request.
 
-Two common tasks are documented there rather than here, since both are contributor workflows: [updating the featured reading carousel](CONTRIBUTING.md#updating-the-featured-reading-carousel) on the homepage, which is driven entirely by [`src/data/featuredLinks.yaml`](src/data/featuredLinks.yaml), and [updating release data](CONTRIBUTING.md#updating-release-data) under `static/data/releases/`, which is normally handled automatically by a scheduled workflow.
+That guide also covers [homepage carousel updates](CONTRIBUTING.md#updating-the-featured-reading-carousel), driven by [`src/data/featuredLinks.yaml`](src/data/featuredLinks.yaml), and [release data updates](CONTRIBUTING.md#updating-release-data) under `static/data/releases/`. A scheduled workflow usually handles the release data.
 
 For questions, join the **#cadence-contributors** channel on the CNCF Slack workspace, or see the [contact page](https://cadenceworkflow.io/community/contact-us) for other options.
 

--- a/README.md
+++ b/README.md
@@ -1,133 +1,68 @@
-# [Cadence docs](https://cadenceworkflow.io) &middot; ![Build and Deploy](https://img.shields.io/github/actions/workflow/status/cadence-workflow/Cadence-Docs/publish-to-gh-pages.yml?label=Build%20and%20Deploy&link=https%3A%2F%2Fgithub.com%2Fcadence-workflow%2FCadence-Docs%2Factions%2Fworkflows%2Fpublish-to-gh-pages.yml) ![Nightly integration test](https://img.shields.io/github/actions/workflow/status/cadence-workflow/Cadence-Docs/nightly-integration-test.yml?label=Nightly%20integration%20test&link=https%3A%2F%2Fgithub.com%2Fcadence-workflow%2FCadence-Docs%2Factions%2Fworkflows%2Fnightly-integration-test.yml)
+# Cadence docs
 
+[![Build and Deploy](https://img.shields.io/github/actions/workflow/status/cadence-workflow/Cadence-Docs/publish-to-gh-pages.yml?label=Build%20and%20Deploy)](https://github.com/cadence-workflow/Cadence-Docs/actions/workflows/publish-to-gh-pages.yml)
+[![Nightly integration test](https://img.shields.io/github/actions/workflow/status/cadence-workflow/Cadence-Docs/nightly-integration-test.yml?label=Nightly%20integration%20test)](https://github.com/cadence-workflow/Cadence-Docs/actions/workflows/nightly-integration-test.yml)
 
+This repository is the source of [cadenceworkflow.io](https://cadenceworkflow.io), the documentation site for [Cadence](https://github.com/cadence-workflow/cadence). It is built with [Docusaurus](https://docusaurus.io/).
 
-# cadenceworkflow.io
+> 📚 **New to contributing to Cadence?** Check out our [Contributing Guide](https://cadenceworkflow.io/community/how-to-contribute/getting-started) for an overview of the contribution process across all Cadence repositories. For setup and development instructions specific to this site, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-[Cadence docs](https://cadenceworkflow.io) is built using [Docusaurus](https://docusaurus.io/).
+## Quick start
 
-> 📚 **New to contributing to Cadence?** Check out our [Contributing Guide](https://cadenceworkflow.io/community/how-to-contribute/getting-started) for an overview of the contribution process across all Cadence repositories. This document contains Cadence backend specific setup and development instructions.
-
-### Installation
+Requires Node.js 22 or newer.
 
 ```console
 npm install
-```
-
-### Local Development
-
-```console
 npm run start
 ```
 
-This command starts a local development server and opens up a browser window at http://localhost:3000/. Most changes are reflected live without having to restart the server.
+This starts a local development server at http://localhost:3000/ and opens a browser window. Most changes are reflected live without restarting the server.
 
-### Build
+To generate the static site into the `build` directory, which can be served by any static host:
 
 ```console
 npm run build
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+[CONTRIBUTING.md](CONTRIBUTING.md) covers the rest: Node version pinning, npm registry configuration, the production preview you should run before opening a pull request, and how to add or move a page.
 
-### Preview the production / GitHub Pages build
+## How the site is deployed
 
-Our [website](https://cadenceworkflow.io) is deployed by using GitHub pages, which are static HTML pages generated from the codebase whereas `npm run start` runs Docusaurus in development mode, injecting styles and updates them with HMR. Before you land your changes you need to check how they are going to look like in the website. Here are the steps to perform that test:
+The live site is published by the **Build and Deploy** workflow ([`publish-to-gh-pages.yml`](.github/workflows/publish-to-gh-pages.yml)), which runs on every push to `master` and can also be triggered manually. It builds with `npm ci && npm run build`, deploys the `build` directory to the `gh-pages` branch, and then asks the Algolia crawler to re-index the site.
 
-Run this once:
+`npm run deploy` also exists as a manual fallback that builds and pushes to `gh-pages` from your machine, using either `USE_SSH=true npm run deploy` or `GIT_USER=<your GitHub username> npm run deploy`. Day to day you should not need it; prefer letting the workflow deploy.
 
-```console
-chmod +x scripts/preview-github-pages-build.sh
-```
+### Configuration
 
-Run this before every test:
+A few options in [`docusaurus.config.ts`](docusaurus.config.ts) can be overridden by environment variables so the site can be deployed to more than one place. The deploy workflow reads them from the repository's `production` environment settings.
 
-```console
-./scripts/preview-github-pages-build.sh --serve      # then open http://localhost:4173/
-```
-
-Alternatively, you can run the following:
-
-```console
-npm run preview:github-pages -- --serve
-```
-
-### Environment Variables
-
-In order to deploy to multiple environments, some configuration options in `docusaurus.config.ts` are made available for override through environment variables.
+The canonical cadenceworkflow.io deployment uses:
 
 ```bash
-# Can be replaced by your GH pages URL, i.e., https://<userId>.github.io/
+# Site origin, used to build absolute URLs.
 CADENCE_DOCS_URL=https://cadenceworkflow.io
 
-# For GitHub Pages project sites (e.g. username.github.io/Cadence-Docs/), use /<repo>/
-# Official cadenceworkflow.io build uses BASE_URL=/
-BASE_URL=/Cadence-Docs/
+# Served from the domain root.
+BASE_URL=/
 
-# For GitHub pages only, this is your GitHub org/user name.
+# GitHub org that owns the repository.
 ORGANIZATION_NAME=cadence-workflow
 ```
 
-#### CNAME
+If a variable is not set, the workflow derives a sensible default from the repository name, so a fork deploys to `/<repo>/` without any configuration. Deploying your own fork for preview purposes is documented in [CONTRIBUTING.md](CONTRIBUTING.md); the values above are for the canonical site and should not be copied to a fork.
 
-A file `static/CNAME` should be present to use a [custom domain for GitHub Pages](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site) (e.g. cadenceworkflow.io). The deploy workflow creates it from **`secrets.CUSTOM_DOMAIN`** (`finnp/create-file-action`).
+### Custom domain
 
-### Deployment
+Serving the site from a [custom domain](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site) such as cadenceworkflow.io requires a `static/CNAME` file, because anything under `static/` is copied to the root of the build output. The file is not committed: the deploy workflow creates it from the `CUSTOM_DOMAIN` secret. Forks have no such secret and therefore no custom domain, which is the intended behavior.
 
-Using SSH:
+## Contributing
 
-```console
-USE_SSH=true npm run deploy
-```
+Documentation contributions are welcome and are a good way to get started with the project. Start with [CONTRIBUTING.md](CONTRIBUTING.md) for how to set up, verify, and submit a change to this site.
 
-Not using SSH:
+Two common tasks are documented there rather than here, since both are contributor workflows: [updating the featured reading carousel](CONTRIBUTING.md#updating-the-featured-reading-carousel) on the homepage, which is driven entirely by [`src/data/featuredLinks.yaml`](src/data/featuredLinks.yaml), and [updating release data](CONTRIBUTING.md#updating-release-data) under `static/data/releases/`, which is normally handled automatically by a scheduled workflow.
 
-```console
-GIT_USER=<Your GitHub username> npm run deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
-
-
-### Updating Release Data
-
-The release pages rely on data from GitHub that is persisted as JSON files under `static/data/releases/`.
-In order to update the release information for display, this can be done manually or be set up as part of the CI/CD process by running the `scripts/fetch-releases.sh` script. Script uses the [GitHub CLI](https://cli.github.com/) to fetch the release data.
-
-Automatic updates to release data are performed by a GitHub Action `fetch-release-data`, which will check if new data is available, and if so, update the release data with the latest information and open a branch named `fetch-release-data` and open a PR if one is not open already.
-
-Manual approval is required before merging and continuing to deployment.
-
-### Updating the Featured Reading Carousel
-
-The homepage "Featured reading" carousel is driven entirely by [`src/data/featuredLinks.yaml`](src/data/featuredLinks.yaml) — no code changes are needed to add, remove, or reorder items. Items are rendered in the order they appear in the file, so add a new entry wherever it should show up in the carousel.
-
-Each entry supports:
-
-- `title` (required): Card headline.
-- `description` (required): One or two short sentences.
-- `href` (required): Internal route (e.g. `/docs/...`) or a full external URL.
-- `tag` (required): One of `Blog`, `Doc`, `Community`, `FAQ`, `Video` (defined in `src/data/featuredTags.ts`). An unrecognized tag fails the build with a clear error.
-- `image` (optional): Overrides the tag's default image. A path under `static/` (e.g. `/img/foo.png`) or a full URL.
-- `cta` (optional): Call-to-action label; defaults to "Read more".
-
-```yaml
-- title: "Introducing Cadence Schedules"
-  description: Cadence Schedules bring first-class recurring workflow execution to the platform.
-  href: /blog/2026/06/23/cadence-schedules
-  tag: Blog
-  cta: Read post
-```
-
-For `Video` items linking to YouTube, the carousel automatically pulls the video's thumbnail as the card image, falling back to the tag's default image if the thumbnail fails to load.
-
-# NPM Registry
-
-Ensure you have a `.npmrc` [file](https://docs.npmjs.com/cli/v9/configuring-npm/npmrc/) configured with `registry=https://registry.npmjs.org/`.
-This will ensure the dependencies are pulled from the correct source and to prevent internal npm registries from being pushed onto the package-lock.json
+For questions, join the **#cadence-contributors** channel on the CNCF Slack workspace, or see the [contact page](https://cadenceworkflow.io/community/contact-us) for other options.
 
 ## License
 
-The source code in this repository is licensed under the Apache 2.0 License.
-The documentation in this repository is licensed under the Creative Commons Attribution 4.0 International License.
-See [LICENSE](https://github.com/cadence-workflow/Cadence-Docs/blob/master/LICENSE.md) for details.
+The source code in this repository is licensed under the Apache License 2.0. The documentation content is licensed under the Creative Commons Attribution 4.0 International License. See [LICENSE.md](LICENSE.md) for details.


### PR DESCRIPTION


**What changed?**

Fills in the empty `CONTRIBUTING.md` with a contributor guide for the docs site, and trims `README.md` to project identity, quick start, and how the live site actually deploys.

**Why?**

`CONTRIBUTING.md` was 0 bytes even though GitHub links to it from every PR, and the README was mixing project identity with contributor workflow and fork-specific config.

- No documented setup: Node version pinning, `.npmrc` for the public registry
- No documented verification: `npm run build`, DCO sign-off, personal Pages preview
- README showed `BASE_URL=/Cadence-Docs/` beside the cadenceworkflow.io domain setup
- README described `npm run deploy` as if that were how the site ships

**How did you verify it?**

- `npm run build` passes.
- Ran `npm run preview:github-pages -- --serve` 


- [x] Ran production preview (`npm run preview:github-pages -- --serve`)
- [x] Checked dark mode and light mode on affected pages — markdown prose only, no styling or component changes

**Potential risks**

`CONTRIBUTING.md` is imported by `community/contributing.mdx`, so this also changes a rendered page at `/community/contributing`, not just a repo file. That page is currently orphaned: its sidebar entry is commented out in `sidebarsCommunity.js` and nothing links to it, so the content is reachable by direct URL only. 

N/A. 
Some unrelated problems surfaced while writing this and are worth their own issues: 
- `communityinviter.com` Slack link used across the site and every repo returns 404
- `cadence-go-client` and `cadence-web` still ask contributors to sign the Uber CLA.