### PR TITLE
docs(tech-review): add installation and validation content

### DIFF
--- a/docs/11-tech-review/01-day-0-planning/04-installation/01-installation-initialization.md
+++ b/docs/11-tech-review/01-day-0-planning/04-installation/01-installation-initialization.md
@@ -8,3 +8,101 @@ keywords:
   - cadence setup
 ---
 
+Cadence offers several installation paths, from a single binary with zero external dependencies to production-grade Kubernetes deployments. The right path depends on the adopter's stage: local evaluation, development and testing, or production.
+
+## Server installation methods
+
+| Method | Best for |
+| --- | --- |
+| **Local binary** | Fastest evaluation, local development |
+| **Docker Compose** | Trying the full stack locally (server + persistence + UI + metrics) |
+| **Kubernetes / Helm** | Staging and production deployments |
+
+### Local binary (minimal install)
+
+For quick evaluation, Cadence can be built and run directly from source:
+
+```bash
+git clone https://github.com/cadence-workflow/cadence.git
+cd cadence
+make bins
+make install-schema-sqlite
+./cadence-server --zone sqlite start
+```
+
+The server starts all four services (frontend, history, matching, worker) on their [default ports](https://github.com/cadence-workflow/cadence/blob/master/config/development.yaml). This is a single-node setup with an embedded database suitable for local development and evaluation.
+
+The [Web UI](https://github.com/cadence-workflow/cadence-web) is a separate project and is not included in the local binary build. Use Docker Compose or Helm for a setup that includes the UI. See the [server README](https://github.com/cadence-workflow/cadence/blob/master/README.md) and [Get Started](/docs/get-started/) for full details.
+
+### Docker Compose
+
+Docker Compose runs the Cadence server, a persistence backend (Cassandra by default), the Web UI, and an observability stack (Prometheus + Grafana) with a single command:
+
+```bash
+git clone https://github.com/cadence-workflow/cadence.git
+cd cadence/docker && docker compose up
+```
+
+The [`docker/`](https://github.com/cadence-workflow/cadence/tree/master/docker) directory includes alternate Compose files for different persistence backends, advanced visibility, metrics, multi-cluster replication, and operational testing. For production Docker usage, use the `auto-setup` image tag for initial schema creation and a release-tagged image for steady-state operation. See the [server README](https://github.com/cadence-workflow/cadence/blob/master/README.md) and the [Docker README](https://github.com/cadence-workflow/cadence/blob/master/docker/README.md) for the full reference.
+
+### Kubernetes / Helm
+
+Cadence publishes a Helm chart that deploys the server (frontend, history, matching, and worker services), schema setup jobs, and optional subcharts for Cassandra, MySQL, PostgreSQL, Elasticsearch, OpenSearch, and Kafka:
+
+```bash
+helm repo add cadence https://cadence-workflow.github.io/cadence-charts
+helm repo update
+helm install cadence-release cadence/cadence -n cadence --create-namespace
+```
+
+The chart defaults to Cassandra with automatic schema initialization. Switching to PostgreSQL or MySQL requires setting the appropriate subchart and persistence driver values. Example values files are provided for common configurations (Cassandra with PVCs, MySQL, PostgreSQL, PostgreSQL + Elasticsearch/OpenSearch, Cloud SQL, TLS, and metrics). See the [Helm chart README](https://github.com/cadence-workflow/cadence-charts/blob/main/charts/cadence/README.md) for the full `values.yaml` reference and the [Helm deployment codelab](/docs/codelabs/helm-deploy-postgres-opensearch) for a step-by-step walkthrough on GKE.
+
+## CLI installation
+
+The Cadence CLI (`cadence`) is the primary tool for domain, workflow, tasklist, and cluster operations. It can be installed independently of the server:
+
+| Method | Command |
+| --- | --- |
+| **Homebrew** | `brew install cadence-workflow` |
+| **Docker** | `docker run --rm ubercadence/cli:<version>` |
+| **From source** | [`make cadence`](https://github.com/cadence-workflow/cadence/blob/master/Makefile) in the server repository |
+
+## Initialization
+
+After installation, the main initialization step is **domain registration**. A domain is the unit of isolation and configuration in Cadence (analogous to a namespace):
+
+```bash
+cadence --domain my-domain domain register --retention 7
+```
+
+For Helm deployments where the CLI is not installed locally, use `kubectl exec` against the frontend pod:
+
+```bash
+kubectl exec -it deployment/cadence-release-frontend -- \
+  cadence --domain my-domain domain register --retention 7
+```
+
+No additional configuration is required for a minimal working setup. For production, adopters configure persistence backends, `numHistoryShards` (set once at cluster creation and immutable afterward), cluster metadata for multi-region replication, archival, advanced visibility, and dynamic configuration. See [Cluster Configuration](/docs/operation-guide/setup) for the full production configuration reference.
+
+## Deployment components
+
+The Cadence server runs four logical services (frontend, history, matching, and worker) which can run as a single combined process or be split across dedicated processes for production scale.
+
+Beyond the server, a complete deployment includes:
+
+| Component | Role | Required |
+| --- | --- | --- |
+| **Persistence database** | Durable storage for workflow execution state. Supports Cassandra, MySQL, PostgreSQL, or SQLite (local development only). | Yes |
+| **Application workers** | User-provided services that host workflow and activity implementations via Cadence SDKs (Go, Java, Python). | Yes (to run workflows) |
+| **Advanced visibility store** | Elasticsearch or OpenSearch, with Kafka for event streaming. Enables rich workflow search queries beyond basic listing. | No |
+| **Web UI** | Browser-based interface for inspecting and managing workflows, domains, and tasklists. Bundled in Docker Compose and Helm deployments. | No |
+| **Metrics stack** | Prometheus + Grafana (default in Docker Compose), Statsd + Graphite, or M3. | No (recommended for production) |
+
+## Related documentation
+
+- **[Get Started](/docs/get-started/)**: 5-minute quickstart
+- **[Server Installation](/docs/get-started/server-installation)**: Docker Compose setup with domain registration and troubleshooting
+- **[Helm deployment codelab](/docs/codelabs/helm-deploy-postgres-opensearch)**: step-by-step Kubernetes walkthrough
+- **[Cluster Configuration](/docs/operation-guide/setup)**: production configuration (static config, dynamic config, persistence, replication)
+- **[Docker README](https://github.com/cadence-workflow/cadence/blob/master/docker/README.md)**: Docker Compose variants and production `docker run` reference
+- **[Helm chart README](https://github.com/cadence-workflow/cadence-charts/blob/main/charts/cadence/README.md)**: full `values.yaml` reference and chart dependencies

--- a/docs/11-tech-review/01-day-0-planning/04-installation/02-validation.md
+++ b/docs/11-tech-review/01-day-0-planning/04-installation/02-validation.md
@@ -8,3 +8,132 @@ keywords:
   - cadence verification
 ---
 
+Validating a Cadence installation means confirming that the server is running, the persistence layer is healthy, and workflows can execute end-to-end. The steps below apply to any installation method; specific commands differ by deployment path.
+
+## 1. Verify server health
+
+### Local binary
+
+The server prints startup logs to stdout. Look for frontend, history, matching, and worker services binding to their configured ports.
+
+### Docker Compose
+
+Check that all containers are running:
+
+```bash
+docker compose ps
+```
+
+The `cadence` container should be `Up` and healthy. If it is not, check logs:
+
+```bash
+docker logs -f docker-cadence-1
+docker logs -f docker-cassandra-1
+```
+
+### Kubernetes / Helm
+
+Wait for all pods to reach `Running` and schema setup jobs to complete:
+
+```bash
+kubectl get pods -l app.kubernetes.io/name=cadence-release -n cadence
+kubectl get jobs -l app.kubernetes.io/component=schema-server -n cadence
+```
+
+Schema jobs should show `Completed` (`1/1`). If pods are not ready, check schema job logs first, as services depend on schema being in place:
+
+```bash
+kubectl logs job/cadence-release-schema-server -n cadence
+```
+
+## 2. Register a test domain and verify
+
+Domain registration is the first functional check. A successful registration confirms the frontend service is reachable and the persistence layer is operational.
+
+**Local CLI (local binary or Docker Compose):**
+
+```bash
+cadence --domain test-domain domain register --retention 1
+cadence --domain test-domain domain describe
+```
+
+**Kubernetes (no local CLI):**
+
+```bash
+kubectl port-forward svc/cadence-release-frontend 7833:7833 -n cadence
+cadence --address localhost:7833 --transport grpc --domain test-domain domain register --retention 1
+```
+
+The `domain describe` output should show `Status: REGISTERED`.
+
+## 3. Run an end-to-end workflow
+
+The strongest validation is executing a real workflow. The [cadence-samples](https://github.com/cadence-workflow/cadence-samples) repository provides ready-to-run examples.
+
+**Go samples (helloworld):**
+
+```bash
+git clone https://github.com/cadence-workflow/cadence-samples.git
+cd cadence-samples
+
+# Start the worker
+go run cmd/samples/recipes/helloworld/main.go
+
+# In another terminal, trigger the workflow
+cadence --domain test-domain workflow start \
+  --tasklist helloworld-tasklist \
+  --workflow_type helloworld_workflow \
+  --execution_timeout 60
+```
+
+Java and Python samples follow the same pattern: start a worker process, then trigger a workflow via the CLI or the SDK.
+
+After triggering the workflow, verify it completed successfully:
+
+```bash
+cadence --domain test-domain workflow list
+```
+
+The workflow should appear with a `Completed` status. The Web UI (default `http://localhost:8088`) provides a visual confirmation: navigate to the test domain and inspect the workflow execution, history events, and activity results.
+
+## 4. Validate advanced visibility (optional)
+
+If Elasticsearch or OpenSearch is deployed, confirm that workflow data is being indexed:
+
+```bash
+cadence --domain test-domain workflow list --query "WorkflowType = 'helloworld_workflow'"
+```
+
+A successful list query with results confirms that the visibility pipeline (Kafka → Elasticsearch/OpenSearch) is operational. For OpenSearch deployments, you can also check the index directly:
+
+```bash
+curl http://localhost:9200/cadence-visibility*/_count
+```
+
+## 5. Validate metrics (production)
+
+For production deployments, confirm that the metrics pipeline is operational. The default Docker Compose setup includes Prometheus and Grafana. Verify Prometheus is scraping Cadence targets:
+
+- **Prometheus:** navigate to `http://localhost:9090/targets` and confirm Cadence endpoints are `UP`.
+- **Grafana:** navigate to `http://localhost:3000` and check the pre-configured Cadence dashboards for incoming data.
+
+For Kubernetes deployments using Prometheus Operator or GMP (Google Managed Prometheus), verify that `PodMonitor` or `ServiceMonitor` resources are picking up Cadence pods. The Helm chart includes an [example `PodMonitoring` values file](https://github.com/cadence-workflow/cadence-charts/blob/main/charts/cadence/examples/values.podmonitoring.yaml) for GKE environments.
+
+Cadence emits metrics for all four services (frontend, history, matching, worker). Seeing request-count and latency metrics after running a test workflow confirms end-to-end metrics collection.
+
+## 6. Operational validation (production)
+
+For production deployments, Cadence provides two additional validation tools:
+
+- **Canary workflows** run periodic health-check workflows that exercise core server functionality. Deploy via `docker compose -f docker-compose-canary.yml up` or as a separate Kubernetes workload. See the [canary README](https://github.com/cadence-workflow/cadence/blob/master/canary/README.md).
+- **Bench workflows** run load tests against the cluster to validate capacity and performance baselines. Deploy via `docker compose -f docker-compose-bench.yml up`. See the [bench README](https://github.com/cadence-workflow/cadence/blob/master/bench/README.md).
+
+Both tools run as Cadence workers that start workflows against the cluster, providing ongoing confidence that the system is functioning correctly under load.
+
+## Related documentation
+
+- **[Server Installation](/docs/get-started/server-installation)**: Docker Compose setup with troubleshooting
+- **[Helm deployment codelab](/docs/codelabs/helm-deploy-postgres-opensearch)**: includes validation and troubleshooting steps
+- **[Monitoring](/docs/operation-guide/monitoring)**: production observability setup
+- **[Troubleshooting](/docs/operation-guide/troubleshooting)**: operational troubleshooting guide
+- **[cadence-samples](https://github.com/cadence-workflow/cadence-samples)**: sample workflows for validation


### PR DESCRIPTION
**What changed?**
Added content to the Day 0 installation questionnaire:
- `01-installation-initialization.md`: server installation methods (local binary, Docker Compose, Helm), CLI installation, initialization via domain registration, and deployment components.
- `02-validation.md`: validation ladder from health checks through domain registration, end-to-end workflows, advanced visibility, metrics, and production canary/bench tools.

**Why?**
Required for the CNCF technical review [Installation](https://github.com/cncf/toc/blob/main/toc_subprojects/project-reviews-subproject/general-technical-questions.md#installation) section.

**How did you verify it?**
Published to GitHub Pages on fork:
- https://vladimir-gavrilenko.github.io/Cadence-Docs/docs/tech-review/day-0-planning/installation/installation-initialization
- https://vladimir-gavrilenko.github.io/Cadence-Docs/docs/tech-review/day-0-planning/installation/validation

**Potential risks**
None: new content only, no changes to existing pages.

**Related changes**
None.
