### PR TITLE
fix(gitar): accept GitHub Pages preview links as PR verification

### DIFF
--- a/.gitar/rules/pr-description-quality.md
+++ b/.gitar/rules/pr-description-quality.md
@@ -38,7 +38,9 @@ From https://cbea.ms/git-commit/#why-not-how:
 
 3. **How did you verify it?**
    - Concrete, copyable steps (e.g. Docusaurus build and/or start, which pages checked)
+   - A link to a personal GitHub Pages deployment (e.g. `https://<user>.github.io/Cadence-Docs/`) also counts as valid verification
    - ✅ GOOD: `npm run build` and `npm run start`, verified docs/concepts/search-workflows and operation-guide/troubleshooting
+   - ✅ GOOD: Verified via GitHub Pages preview at `https://<user>.github.io/Cadence-Docs/docs/...`
    - ❌ BAD: "Built locally" or "Looks good"
    - If link checker or lint was used, include the command
    - **If the PR modifies non-text files** (see item 4 below), verification **must** include production preview and dark/light mode — flag if missing


### PR DESCRIPTION
**What changed?**
Updated the PR description quality rule to accept personal GitHub Pages deployment links as valid verification in the "How did you verify it?" section.

**Why?**
Gitar was flagging PRs that included a GitHub Pages preview link as insufficient verification. A deployed preview is a concrete, verifiable step that confirms the build succeeded and pages render correctly.

**How did you verify it?**
Reviewed the rule definition and confirmed the new example matches the existing pattern of good/bad examples.

**Potential risks**
None. Only affects Gitar rule evaluation, not site content.

**Related changes**
N/A
